### PR TITLE
DM-39563: Test now raises FileNotFoundError

### DIFF
--- a/tests/test_butlerUtils.py
+++ b/tests/test_butlerUtils.py
@@ -412,7 +412,7 @@ class ButlerInitTestCase(lsst.utils.tests.TestCase):
         # If DAF_BUTLER_REPOSITORY_INDEX is present but is just an empty
         # string then using a label raises a RuntimeError
         with unittest.mock.patch.dict(os.environ, {"DAF_BUTLER_REPOSITORY_INDEX": ''}):
-            with self.assertRaises(RuntimeError):
+            with self.assertRaises(FileNotFoundError):
                 dafButler.Butler('LATISS')
 
         # If DAF_BUTLER_REPOSITORY_INDEX _is_ set, we can't rely on any given


### PR DESCRIPTION
Previously the repository index look up system was not being caught properly and so the RuntimeError printed through from the Config code. Now we catch this problem internally and allow the requested repo alias to be used. This changes the exception type being caught in the test.

Requires lsst/daf_butler#849