### PR TITLE
DM-39622: Add plotting for images.

### DIFF
--- a/python/lsst/summit/utils/plotting.py
+++ b/python/lsst/summit/utils/plotting.py
@@ -25,7 +25,7 @@ from lsst.afw.detection import FootprintSet
 from lsst.afw.table import SourceCatalog
 import lsst.geom as geom
 from lsst.summit.utils import getQuantiles
-import lsst.afw.image as Image
+import lsst.afw.image as afwImage
 
 import matplotlib.pyplot as plt
 import matplotlib.colors as colors
@@ -103,15 +103,15 @@ def plot(inputData,
     match inputData:
         case np.ndarray():
             imageData = inputData
-        case Image.MaskedImage():
-            imageData = inputData.getImage().array
-        case Image.Image():
+        case afwImage.MaskedImage():
+            imageData = inputData.image.array
+        case afwImage.Image():
             imageData = inputData.array
-        case Image.Exposure():
+        case afwImage.Exposure():
             imageData = inputData.image.array
         case _:
             raise TypeError("This function accepts numpy array, lsst.afw.image.Exposure components. "
-                  f"Got {type(inputData)}: {inputData}")
+                  "Got type(inputData)")
 
     match stretch:
         case 'ccs':
@@ -138,7 +138,8 @@ def plot(inputData,
                                       interval=vis.PercentileInterval(percentile),
                                       stretch=vis.SqrtStretch())
         case _:
-            norm = None
+            raise ValueError(f"Invalid value for stretch : {stretch}. "
+                    "Accepted options are: ccs, asinh, power, log, linear, sqrt.")
 
     ax.imshow(imageData, cmap=cmap, origin='lower', norm=norm)
 

--- a/python/lsst/summit/utils/plotting.py
+++ b/python/lsst/summit/utils/plotting.py
@@ -1,0 +1,211 @@
+# This file is part of summit_utils.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import numpy as np
+
+from lsst.afw.detection import FootprintSet
+from lsst.afw.table import SourceCatalog
+import lsst.geom as geom
+import lsst.summit.utils as utils
+import lsst.afw.image as Image
+
+import matplotlib.pyplot as plt
+import matplotlib.colors as colors
+
+import astropy.visualization as vis
+
+
+def makePlot(inData, imageType='image', ax=None, centroids=None, compass=False, coordGrid=False,
+             stretch=None, percentile=99., cmap='gray_r', anchorPix=250,
+             legend=True, savePlotAs=None):
+
+    """Make a plot.
+
+    Parameters
+    ----------
+    inData : `numpy.array`, `lsst.afw.image.exposure`, or
+             `lsst.afw.image.Image`
+        The input data.
+    imageType : `str`, optional
+        If input data is an exposure, plot either 'image', or 'masked' image.
+        Defaults to 'image'.
+    ax : `matplotlib.axes.Axes`, optional
+         The Matplotlib axis containing the image data plot.
+    centroids : `list`
+        The centroids parameter represents a collection of centroid data.
+        It can be a combination of different types of data:
+
+        - List of tuples: Each tuple is a centroid with its (X,Y) coordinates.
+        - FootprintSet: lsst.afw.detection.FootprintSet object.
+        - SourceCatalog: A lsst.afw.table.SourceCatalog object.
+
+        You can provide any combination of these data types within the list.
+        The function will plot the centroid data accordingly.
+    compass : `bool`, optional
+        Add compass to the plot? Defaults to False.
+    coordGrid : `bool`, optional
+        Add coordinate grid to the plot? Defaults to False.
+    stretch : `str', optional
+        Changes mapping of colors for the image. Avaliable options:
+        css, log, power, asinh, linear, sqrt. Defaults to None.
+    percentile : `float', optional
+        Parameter for astropy.visualization.PercentileInterval:
+        The fraction of pixels to keep. The same fraction of pixels
+        is eliminated from both ends. Here: defaults to 99.
+    cmap : `str`, optional
+        matplotlib colormap. Defaults to 'gray_r'.
+    anchorPix : `int`, optional
+        The coordinate of pixel to anchor the compass.
+    legend : `bool',optional
+       Add legend to plot.
+    savePlotAs : `str`, optional
+        The name of the file to save the plot as, including the file extension.
+        The extention must be supported by `matplotlib.pyplot`.
+        If None (default) plot will not be saved.
+
+    Returns
+    -------
+    ax : `matplotlib.axes.Axes`
+        A plot showing image data.
+    """
+
+    if not ax:
+        fig = plt.figure(figsize=(10, 10))
+        ax = fig.add_subplot(111)
+
+    match inData:
+        case np.ndarray():
+            imData = inData
+        case Image._maskedImage.MaskedImageF():
+            imData = inData.getImage().array
+        case Image._image.ImageF():
+            imData = inData.array
+        case Image._exposure.ExposureF():
+            match imageType:
+                case 'image':
+                    imData = inData.image.array
+                case 'masked':
+                    imData = inData.getMaskedImage().getImage().array
+        case _:
+            raise TypeError("This function accepts numpy array, lsst.afw.image.Exposure components. "
+                  f"Got {type(inData)}: {inData}")
+
+    # Add stretching
+    match stretch:
+        case 'css':
+            quantiles = utils.getQuantiles(imData, 256)
+            norm = colors.BoundaryNorm(quantiles, 256)
+        case 'asinh':
+            norm = vis.ImageNormalize(imData,
+                                      interval=vis.PercentileInterval(percentile),
+                                      stretch=vis.AsinhStretch(a=0.1))
+        case 'power':
+            norm = vis.ImageNormalize(imData,
+                                      interval=vis.PercentileInterval(percentile),
+                                      stretch=vis.PowerStretch(a=2))
+        case 'log':
+            norm = vis.ImageNormalize(imData,
+                                      interval=vis.PercentileInterval(percentile),
+                                      stretch=vis.LogStretch(a=1))
+        case 'linear':
+            norm = vis.ImageNormalize(imData,
+                                      interval=vis.PercentileInterval(percentile),
+                                      stretch=vis.LinearStretch())
+        case 'sqrt':
+            norm = vis.ImageNormalize(imData,
+                                      interval=vis.PercentileInterval(percentile),
+                                      stretch=vis.SqrtStretch())
+        case _:
+            norm = None
+
+    ax.imshow(imData, cmap=cmap, origin='lower', norm=norm)
+
+    # Add grid
+    if coordGrid:
+        ax.grid(color='white', ls='solid')
+
+    # Add compass
+    if compass:
+        color = 'r'
+        try:
+            wcs = inData.getWcs()
+        except AttributeError:
+            wcs = None
+
+        if wcs:
+            anchorRa, anchorDec = wcs.pixelToSky(anchorPix, anchorPix)
+            east = wcs.skyToPixel(geom.SpherePoint(anchorRa + 30.0 * geom.arcseconds, anchorDec))
+            north = wcs.skyToPixel(geom.SpherePoint(anchorRa, anchorDec + 30. * geom.arcseconds))
+
+            ax.arrow(anchorPix, anchorPix, north[0]-anchorPix, north[1]-anchorPix,
+                     head_width=1., head_length=1., color=color)
+            ax.arrow(anchorPix, anchorPix, east[0]-anchorPix, east[1]-anchorPix,
+                     head_width=1., head_length=1., color=color)
+            ax.text(north[0], north[1], 'N', color=color)
+            ax.text(east[0], east[1], 'E', color=color)
+
+    # Add centroids
+    if centroids:
+        cCycle = ['r', 'b', 'g', 'c', 'm', 'y', 'k']
+        # Create a dict with points from different sources
+        cenDict = {}
+        c_fs, c_sc, c_lst = 0, 0, 0  # index for color
+        for cenSet in centroids:
+            match cenSet:
+                case FootprintSet():
+                    fs = FootprintSet.getFootprints(cenSet)
+                    xy = [_.getCentroid() for _ in fs]
+                    key = 'footprintSet'+str(c_fs)
+                    cenDict[key] = {'data': xy}
+                    cenDict[key]['m'] = '+'
+                    cenDict[key]['c'] = cCycle[c_fs]
+                    c_fs += 1
+                case SourceCatalog():
+                    key = 'SourceCatalog'+str(c_sc)
+                    xy = list(zip(cenSet.getX(), cenSet.getY()))
+                    cenDict[key] = {'data': xy}
+                    cenDict[key]['m'] = 'x'
+                    cenDict[key]['c'] = cCycle[c_sc]
+                    c_sc += 1
+                case list():
+                    key = 'tupleList'+str(c_lst)
+                    cenDict[key] = {'data': cenSet}
+                    cenDict[key]['m'] = 's'
+                    cenDict[key]['c'] = cCycle[c_lst]
+                    c_lst += 1
+                case _:  # inData type cannot be used here
+                    raise TypeError("This function accepts a list of SourceCatalog, \
+                                     list of tuples, and/or FootprintSet. "
+                                    f"Got {type(cenSet)}: {cenSet}")
+
+        for cSet in cenDict:
+            ax.plot(*zip(*cenDict[cSet]['data']),
+                    marker=cenDict[cSet]['m'],
+                    markeredgecolor=cenDict[cSet]['c'],
+                    markerfacecolor='None',
+                    linestyle='None', label=cSet)
+
+        if legend:
+            ax.legend(loc='upper center', bbox_to_anchor=(0.5, -0.05), ncol=5)
+    if savePlotAs:
+        plt.savefig(savePlotAs)
+
+    return ax

--- a/python/lsst/summit/utils/plotting.py
+++ b/python/lsst/summit/utils/plotting.py
@@ -49,8 +49,8 @@ def plot(inputData,
 
     Parameters
     ----------
-    inputData : `numpy.array`, `lsst.afw.image.exposure`, or
-        `lsst.afw.image.Image`
+    inputData : `numpy.array`, `lsst.afw.image.Exposure`,
+        `lsst.afw.image.Image`, or `lsst.afw.image.MaskedImage`
         The input data.
     imageType : `str`, optional
         If input data is an exposure, plot either 'image', or 'masked' image.

--- a/python/lsst/summit/utils/plotting.py
+++ b/python/lsst/summit/utils/plotting.py
@@ -139,7 +139,7 @@ def plot(inputData,
                                       stretch=vis.SqrtStretch())
         case _:
             raise ValueError(f"Invalid value for stretch : {stretch}. "
-                    "Accepted options are: ccs, asinh, power, log, linear, sqrt.")
+                             "Accepted options are: ccs, asinh, power, log, linear, sqrt.")
 
     ax.imshow(imageData, cmap=cmap, origin='lower', norm=norm)
 

--- a/python/lsst/summit/utils/plotting.py
+++ b/python/lsst/summit/utils/plotting.py
@@ -24,7 +24,7 @@ import numpy as np
 from lsst.afw.detection import FootprintSet
 from lsst.afw.table import SourceCatalog
 import lsst.geom as geom
-import lsst.summit.utils as utils
+from lsst.summit.utils import getQuantiles
 import lsst.afw.image as Image
 
 import matplotlib.pyplot as plt
@@ -33,16 +33,24 @@ import matplotlib.colors as colors
 import astropy.visualization as vis
 
 
-def makePlot(inData, imageType='image', ax=None, centroids=None, compass=False, coordGrid=False,
-             stretch=None, percentile=99., cmap='gray_r', anchorPix=250,
-             legend=True, savePlotAs=None):
+def plot(inputData,
+         figure=None,
+         centroids=None,
+         title=None,
+         showCompass=False,
+         stretch='linear',
+         percentile=99.,
+         cmap='gray_r',
+         compassLocation=250,
+         addLegend=True,
+         savePlotAs=None):
 
     """Make a plot.
 
     Parameters
     ----------
-    inData : `numpy.array`, `lsst.afw.image.exposure`, or
-             `lsst.afw.image.Image`
+    inputData : `numpy.array`, `lsst.afw.image.exposure`, or
+        `lsst.afw.image.Image`
         The input data.
     imageType : `str`, optional
         If input data is an exposure, plot either 'image', or 'masked' image.
@@ -59,23 +67,24 @@ def makePlot(inData, imageType='image', ax=None, centroids=None, compass=False, 
 
         You can provide any combination of these data types within the list.
         The function will plot the centroid data accordingly.
-    compass : `bool`, optional
+    title : `str`, optional
+        Title for the plot.
+    showCompass : `bool`, optional
         Add compass to the plot? Defaults to False.
-    coordGrid : `bool`, optional
-        Add coordinate grid to the plot? Defaults to False.
     stretch : `str', optional
         Changes mapping of colors for the image. Avaliable options:
-        css, log, power, asinh, linear, sqrt. Defaults to None.
+        ccs, log, power, asinh, linear, sqrt. Defaults to linear.
     percentile : `float', optional
         Parameter for astropy.visualization.PercentileInterval:
         The fraction of pixels to keep. The same fraction of pixels
         is eliminated from both ends. Here: defaults to 99.
     cmap : `str`, optional
         matplotlib colormap. Defaults to 'gray_r'.
-    anchorPix : `int`, optional
-        The coordinate of pixel to anchor the compass.
-    legend : `bool',optional
-       Add legend to plot.
+    compassLocation : `int`, optional
+        How far in from the bottom left of the image to display the compass.
+        By default, compass will be placed at pixel (X,Y) = (250,250).
+    addLegend : `bool', optional
+       Add legend to the plot.
     savePlotAs : `str`, optional
         The name of the file to save the plot as, including the file extension.
         The extention must be supported by `matplotlib.pyplot`.
@@ -83,81 +92,73 @@ def makePlot(inData, imageType='image', ax=None, centroids=None, compass=False, 
 
     Returns
     -------
-    ax : `matplotlib.axes.Axes`
-        A plot showing image data.
+    fig : `matplotlib.figure.Figure`
+        The rendered image.
     """
 
-    if not ax:
-        fig = plt.figure(figsize=(10, 10))
-        ax = fig.add_subplot(111)
+    if not figure:
+        figure = plt.figure(figsize=(10, 10))
+        ax = figure.add_subplot(111)
 
-    match inData:
+    match inputData:
         case np.ndarray():
-            imData = inData
-        case Image._maskedImage.MaskedImageF():
-            imData = inData.getImage().array
-        case Image._image.ImageF():
-            imData = inData.array
-        case Image._exposure.ExposureF():
-            match imageType:
-                case 'image':
-                    imData = inData.image.array
-                case 'masked':
-                    imData = inData.getMaskedImage().getImage().array
+            imageData = inputData
+        case Image.MaskedImage():
+            imageData = inputData.getImage().array
+        case Image.Image():
+            imageData = inputData.array
+        case Image.Exposure():
+            imageData = inputData.image.array
         case _:
             raise TypeError("This function accepts numpy array, lsst.afw.image.Exposure components. "
-                  f"Got {type(inData)}: {inData}")
+                  f"Got {type(inputData)}: {inputData}")
 
-    # Add stretching
     match stretch:
-        case 'css':
-            quantiles = utils.getQuantiles(imData, 256)
+        case 'ccs':
+            quantiles = getQuantiles(imageData, 256)
             norm = colors.BoundaryNorm(quantiles, 256)
         case 'asinh':
-            norm = vis.ImageNormalize(imData,
+            norm = vis.ImageNormalize(imageData,
                                       interval=vis.PercentileInterval(percentile),
                                       stretch=vis.AsinhStretch(a=0.1))
         case 'power':
-            norm = vis.ImageNormalize(imData,
+            norm = vis.ImageNormalize(imageData,
                                       interval=vis.PercentileInterval(percentile),
                                       stretch=vis.PowerStretch(a=2))
         case 'log':
-            norm = vis.ImageNormalize(imData,
+            norm = vis.ImageNormalize(imageData,
                                       interval=vis.PercentileInterval(percentile),
                                       stretch=vis.LogStretch(a=1))
         case 'linear':
-            norm = vis.ImageNormalize(imData,
+            norm = vis.ImageNormalize(imageData,
                                       interval=vis.PercentileInterval(percentile),
                                       stretch=vis.LinearStretch())
         case 'sqrt':
-            norm = vis.ImageNormalize(imData,
+            norm = vis.ImageNormalize(imageData,
                                       interval=vis.PercentileInterval(percentile),
                                       stretch=vis.SqrtStretch())
         case _:
             norm = None
 
-    ax.imshow(imData, cmap=cmap, origin='lower', norm=norm)
+    ax.imshow(imageData, cmap=cmap, origin='lower', norm=norm)
 
-    # Add grid
-    if coordGrid:
-        ax.grid(color='white', ls='solid')
-
-    # Add compass
-    if compass:
+    if showCompass:
         color = 'r'
         try:
-            wcs = inData.getWcs()
+            wcs = inputData.getWcs()
         except AttributeError:
             wcs = None
 
         if wcs:
-            anchorRa, anchorDec = wcs.pixelToSky(anchorPix, anchorPix)
+            anchorRa, anchorDec = wcs.pixelToSky(compassLocation, compassLocation)
             east = wcs.skyToPixel(geom.SpherePoint(anchorRa + 30.0 * geom.arcseconds, anchorDec))
             north = wcs.skyToPixel(geom.SpherePoint(anchorRa, anchorDec + 30. * geom.arcseconds))
 
-            ax.arrow(anchorPix, anchorPix, north[0]-anchorPix, north[1]-anchorPix,
+            ax.arrow(compassLocation, compassLocation,
+                     north[0]-compassLocation, north[1]-compassLocation,
                      head_width=1., head_length=1., color=color)
-            ax.arrow(anchorPix, anchorPix, east[0]-anchorPix, east[1]-anchorPix,
+            ax.arrow(compassLocation, compassLocation,
+                     east[0]-compassLocation, east[1]-compassLocation,
                      head_width=1., head_length=1., color=color)
             ax.text(north[0], north[1], 'N', color=color)
             ax.text(east[0], east[1], 'E', color=color)
@@ -191,9 +192,9 @@ def makePlot(inData, imageType='image', ax=None, centroids=None, compass=False, 
                     cenDict[key]['m'] = 's'
                     cenDict[key]['c'] = cCycle[c_lst]
                     c_lst += 1
-                case _:  # inData type cannot be used here
+                case _:
                     raise TypeError("This function accepts a list of SourceCatalog, \
-                                     list of tuples, and/or FootprintSet. "
+                                     list of tuples, or FootprintSet. "
                                     f"Got {type(cenSet)}: {cenSet}")
 
         for cSet in cenDict:
@@ -203,9 +204,11 @@ def makePlot(inData, imageType='image', ax=None, centroids=None, compass=False, 
                     markerfacecolor='None',
                     linestyle='None', label=cSet)
 
-        if legend:
+        if addLegend:
             ax.legend(loc='upper center', bbox_to_anchor=(0.5, -0.05), ncol=5)
+    if title:
+        ax.set_title(title)
     if savePlotAs:
         plt.savefig(savePlotAs)
 
-    return ax
+    return figure

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -47,7 +47,7 @@ class PlottingTestCase(lsst.utils.tests.TestCase):
         """
         exp = self.butler.get('raw', self.dataId)
         centroids = [(567, 746), (576, 599), (678, 989)]
-        
+
         # Input is an exposure
         outputFilename = os.path.join(self.outputDir, 'testPlotting_exp.jpg')
         plot(exp,

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -26,7 +26,7 @@ import os
 import lsst.utils.tests
 
 from lsst.summit.utils.butlerUtils import makeDefaultLatissButler
-from lsst.summit.utils.plotting import makePlot
+from lsst.summit.utils.plotting import plot
 
 
 class PlottingTestCase(lsst.utils.tests.TestCase):
@@ -50,46 +50,42 @@ class PlottingTestCase(lsst.utils.tests.TestCase):
 
         # Input is an exposure
         outputFilename = os.path.join(self.outputDir, 'testPlotting_exp.jpg')
-        plot1 = makePlot(exp,
-                         centroids=[centroids],
-                         compass=True,
-                         savePlotAs=outputFilename)
-        plot1.plot()
+        plot1 = plot(exp,
+                     centroids=[centroids],
+                     showCompass=True,
+                     savePlotAs=outputFilename)
         self.assertTrue(os.path.isfile(outputFilename))
         self.assertTrue(os.path.getsize(outputFilename) > 10000)
 
         # Input is a numpy array
         outputFilename = os.path.join(self.outputDir, 'testPlotting_nparr.jpg')
         nparr = exp.getImage().array
-        plot2 = makePlot(nparr,
-                         compass=True,
-                         centroids=[centroids],
-                         savePlotAs=outputFilename)
-        plot2.plot()
+        plot2 = plot(nparr,
+                     showCompass=True,
+                     centroids=[centroids],
+                     savePlotAs=outputFilename)
         self.assertTrue(os.path.isfile(outputFilename))
         self.assertTrue(os.path.getsize(outputFilename) > 10000)
 
         # Input is an image
         outputFilename = os.path.join(self.outputDir, 'testPlotting_image.jpg')
         im = exp.getImage()
-        plot3 = makePlot(im,
-                         compass=True,
-                         centroids=[centroids],
-                         savePlotAs=outputFilename)
-        plot3.plot()
+        plot3 = plot(im,
+                     showCompass=True,
+                     centroids=[centroids],
+                     savePlotAs=outputFilename)
         self.assertTrue(os.path.isfile(outputFilename))
         self.assertTrue(os.path.getsize(outputFilename) > 10000)
 
         # Input is a masked image
-        outputFilename = os.path.join(self.outputDir, 'testPlotting_masked.jpg')
-        plot4 = makePlot(exp,
-                         imageType='masked',
-                         compass=True,
-                         centroids=[centroids],
-                         savePlotAs=outputFilename)
-        plot4.plot()
-        self.assertTrue(os.path.isfile(outputFilename))
-        self.assertTrue(os.path.getsize(outputFilename) > 10000)
+#        outputFilename = os.path.join(self.outputDir, 'testPlotting_masked.jpg')
+#        plot4 = plot(exp,
+#                     showCompass=True,
+#                     centroids=[centroids],
+#                     savePlotAs=outputFilename)
+#        plot4.plot()
+#        self.assertTrue(os.path.isfile(outputFilename))
+#        self.assertTrue(os.path.getsize(outputFilename) > 10000)
 
 
 def setup_module(module):

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -1,0 +1,101 @@
+# This file is part of summit_utils.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+import unittest
+import tempfile
+import os
+
+import lsst.utils.tests
+
+from lsst.summit.utils.butlerUtils import makeDefaultLatissButler
+from lsst.summit.utils.plotting import makePlot
+
+
+class PlottingTestCase(lsst.utils.tests.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        try:
+            cls.butler = makeDefaultLatissButler()
+        except FileNotFoundError:
+            raise unittest.SkipTest("Skipping tests that require the LATISS butler repo.")
+
+        # Chosen to work on the TTS, summit and NCSA
+        cls.dataId = {'day_obs': 20200315, 'seq_num': 120, 'detector': 0}
+        cls.outputDir = tempfile.mkdtemp()
+
+    def test_plotting(self):
+        """Test that the the plot is made and saved
+        """
+        exp = self.butler.get('raw', self.dataId)
+        centroids = [(567, 746), (576, 599), (678, 989)]
+
+        # Input is an exposure
+        outputFilename = os.path.join(self.outputDir, 'testPlotting_exp.jpg')
+        plot1 = makePlot(exp,
+                         centroids=[centroids],
+                         compass=True,
+                         savePlotAs=outputFilename)
+        plot1.plot()
+        self.assertTrue(os.path.isfile(outputFilename))
+        self.assertTrue(os.path.getsize(outputFilename) > 10000)
+
+        # Input is a numpy array
+        outputFilename = os.path.join(self.outputDir, 'testPlotting_nparr.jpg')
+        nparr = exp.getImage().array
+        plot2 = makePlot(nparr,
+                         compass=True,
+                         centroids=[centroids],
+                         savePlotAs=outputFilename)
+        plot2.plot()
+        self.assertTrue(os.path.isfile(outputFilename))
+        self.assertTrue(os.path.getsize(outputFilename) > 10000)
+
+        # Input is an image
+        outputFilename = os.path.join(self.outputDir, 'testPlotting_image.jpg')
+        im = exp.getImage()
+        plot3 = makePlot(im,
+                         compass=True,
+                         centroids=[centroids],
+                         savePlotAs=outputFilename)
+        plot3.plot()
+        self.assertTrue(os.path.isfile(outputFilename))
+        self.assertTrue(os.path.getsize(outputFilename) > 10000)
+
+        # Input is a masked image
+        outputFilename = os.path.join(self.outputDir, 'testPlotting_masked.jpg')
+        plot4 = makePlot(exp,
+                         imageType='masked',
+                         compass=True,
+                         centroids=[centroids],
+                         savePlotAs=outputFilename)
+        plot4.plot()
+        self.assertTrue(os.path.isfile(outputFilename))
+        self.assertTrue(os.path.getsize(outputFilename) > 10000)
+
+
+def setup_module(module):
+    lsst.utils.tests.init()
+
+
+if __name__ == "__main__":
+    lsst.utils.tests.init()
+    unittest.main()

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -50,39 +50,39 @@ class PlottingTestCase(lsst.utils.tests.TestCase):
 
         # Input is an exposure
         outputFilename = os.path.join(self.outputDir, 'testPlotting_exp.jpg')
-        plot1 = plot(exp,
-                     centroids=[centroids],
-                     showCompass=True,
-                     savePlotAs=outputFilename)
+        plot(exp,
+             centroids=[centroids],
+             showCompass=True,
+             savePlotAs=outputFilename)
         self.assertTrue(os.path.isfile(outputFilename))
         self.assertTrue(os.path.getsize(outputFilename) > 10000)
 
         # Input is a numpy array
         outputFilename = os.path.join(self.outputDir, 'testPlotting_nparr.jpg')
         nparr = exp.getImage().array
-        plot2 = plot(nparr,
-                     showCompass=True,
-                     centroids=[centroids],
-                     savePlotAs=outputFilename)
+        plot(nparr,
+             showCompass=True,
+             centroids=[centroids],
+             savePlotAs=outputFilename)
         self.assertTrue(os.path.isfile(outputFilename))
         self.assertTrue(os.path.getsize(outputFilename) > 10000)
 
         # Input is an image
         outputFilename = os.path.join(self.outputDir, 'testPlotting_image.jpg')
         im = exp.getImage()
-        plot3 = plot(im,
-                     showCompass=True,
-                     centroids=[centroids],
-                     savePlotAs=outputFilename)
+        plot(im,
+             showCompass=True,
+             centroids=[centroids],
+             savePlotAs=outputFilename)
         self.assertTrue(os.path.isfile(outputFilename))
         self.assertTrue(os.path.getsize(outputFilename) > 10000)
 
         # Input is a masked image
-#        outputFilename = os.path.join(self.outputDir, 'testPlotting_masked.jpg')
-#        plot4 = plot(exp,
-#                     showCompass=True,
-#                     centroids=[centroids],
-#                     savePlotAs=outputFilename)
+#       outputFilename = os.path.join(self.outputDir, 'testPloting_mask.jpg')
+#        plot(exp,
+#             showCompass=True,
+#             centroids=[centroids],
+#             savePlotAs=outputFilename)
 #        plot4.plot()
 #        self.assertTrue(os.path.isfile(outputFilename))
 #        self.assertTrue(os.path.getsize(outputFilename) > 10000)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -42,12 +42,12 @@ class PlottingTestCase(lsst.utils.tests.TestCase):
         cls.dataId = {'day_obs': 20200315, 'seq_num': 120, 'detector': 0}
         cls.outputDir = tempfile.mkdtemp()
 
-    def test_plotting(self):
+    def test_plot(self):
         """Test that the the plot is made and saved
         """
         exp = self.butler.get('raw', self.dataId)
         centroids = [(567, 746), (576, 599), (678, 989)]
-
+        
         # Input is an exposure
         outputFilename = os.path.join(self.outputDir, 'testPlotting_exp.jpg')
         plot(exp,
@@ -59,7 +59,7 @@ class PlottingTestCase(lsst.utils.tests.TestCase):
 
         # Input is a numpy array
         outputFilename = os.path.join(self.outputDir, 'testPlotting_nparr.jpg')
-        nparr = exp.getImage().array
+        nparr = exp.image.array
         plot(nparr,
              showCompass=True,
              centroids=[centroids],
@@ -69,7 +69,7 @@ class PlottingTestCase(lsst.utils.tests.TestCase):
 
         # Input is an image
         outputFilename = os.path.join(self.outputDir, 'testPlotting_image.jpg')
-        im = exp.getImage()
+        im = exp.image
         plot(im,
              showCompass=True,
              centroids=[centroids],
@@ -78,14 +78,14 @@ class PlottingTestCase(lsst.utils.tests.TestCase):
         self.assertTrue(os.path.getsize(outputFilename) > 10000)
 
         # Input is a masked image
-#       outputFilename = os.path.join(self.outputDir, 'testPloting_mask.jpg')
-#        plot(exp,
-#             showCompass=True,
-#             centroids=[centroids],
-#             savePlotAs=outputFilename)
-#        plot4.plot()
-#        self.assertTrue(os.path.isfile(outputFilename))
-#        self.assertTrue(os.path.getsize(outputFilename) > 10000)
+        outputFilename = os.path.join(self.outputDir, 'testPloting_mask.jpg')
+        masked = exp.maskedImage
+        plot(masked,
+             showCompass=True,
+             centroids=[centroids],
+             savePlotAs=outputFilename)
+        self.assertTrue(os.path.isfile(outputFilename))
+        self.assertTrue(os.path.getsize(outputFilename) > 10000)
 
 
 def setup_module(module):


### PR DESCRIPTION
- plot data from different objects (Image, MaskedImage, Exposure, numpy.array)
- add centroids from list, sourceCatalog, FootprintSet
- add compass and/or grid to plot
- options to select the stretch.