### PR TITLE
DM-42874 : Tweak PeekExposureTask

### DIFF
--- a/python/lsst/summit/utils/peekExposure.py
+++ b/python/lsst/summit/utils/peekExposure.py
@@ -839,6 +839,35 @@ class PeekExposureTask(pipeBase.Task):
                 - pixelMode : `float`
                     Mode estimate of entire image.
         """
+        # Make a copy so the original image is unmodified.
+        exposure = exposure.clone()
+        try:
+            result = self._run(
+                exposure, doDisplay, doDisplayIndices, mode, binSize, donutDiameter
+            )
+        except Exception as e:
+            self.log.warning(f"Peek failed: {e}")
+            result = pipeBase.Struct(
+                mode="failed",
+                binSize=0,
+                binnedSourceCat=None,
+                table=None,
+                brightestIdx=0,
+                brightestCentroid=Point2D(np.nan, np.nan),
+                brightestPixelShape=Quadrupole(np.nan, np.nan, np.nan),
+                brightestEquatorialShape=Quadrupole(np.nan, np.nan, np.nan),
+                brightestAltAzShape=Quadrupole(np.nan, np.nan, np.nan),
+                psfPixelShape=Quadrupole(np.nan, np.nan, np.nan),
+                psfEquatorialShape=Quadrupole(np.nan, np.nan, np.nan),
+                psfAltAzShape=Quadrupole(np.nan, np.nan, np.nan),
+                pixelMedian=np.nan,
+                pixelMode=np.nan,
+            )
+        return result
+
+    def _run(self, exposure, doDisplay, doDisplayIndices, mode, binSize, donutDiameter):
+        """ The actual run method, called by run().
+        """
         if donutDiameter is None:
             donutDiameter = self.getDonutDiameter(exposure)
 


### PR DESCRIPTION
- Computes median/mode of pixel values _before_ subtracting the background
- Keeps the original exposure unmodified