### PR TITLE
DM-44387: Add several convenience methods.

### DIFF
--- a/python/lsst/summit/utils/consdbClient.py
+++ b/python/lsst/summit/utils/consdbClient.py
@@ -165,58 +165,6 @@ class ConsDbClient:
         return response
 
     @staticmethod
-    def compute_exposure_id(instrument: str, controller: str, day_obs: int, seq_num) -> int:
-        instrument = instrument.lower()
-        if instrument == "latiss":
-            from lsst.obs.lsst.translators import LatissTranslator
-
-            return LatissTranslator.compute_exposure_id(day_obs, seq_num, controller)
-        elif instrument == "lsstcomcam":
-            from lsst.obs.lsst.translators import LsstComCamTranslator
-
-            return LsstComCamTranslator.compute_exposure_id(day_obs, seq_num, controller)
-        elif instrument == "lsstcomcamsim":
-            from lsst.obs.lsst.translators import LsstComCamSimTranslator
-
-            return LsstComCamSimTranslator.compute_exposure_id(day_obs, seq_num, controller)
-        elif instrument == "lsstcam":
-            from lsst.obs.lsst.translators import LsstCamTranslator
-
-            return LsstCamTranslator.compute_exposure_id(day_obs, seq_num, controller)
-        else:
-            raise ValueError("Unknown instrument {instrument}")
-
-    @staticmethod
-    def compute_ccdexposure_id(instrument: str, exposure_id: int, detector: int) -> int:
-        instrument = instrument.lower()
-        if instrument == "latiss":
-            if detector != 0:
-                raise ValueError("Invalid detector {detector} for LATISS")
-            from lsst.obs.lsst.translators import LatissTranslator
-
-            return LatissTranslator.compute_detector_exposure_id(exposure_id, detector)
-        elif instrument == "lsstcomcam":
-            if detector < 0 or detector >= 9:
-                raise ValueError("Invalid detector {detector} for LSSTComCam")
-            from lsst.obs.lsst.translators import LsstComCamTranslator
-
-            return LsstComCamTranslator.compute_detector_exposure_id(exposure_id, detector)
-        elif instrument == "lsstcomcamsim":
-            if detector < 0 or detector >= 9:
-                raise ValueError("Invalid detector {detector} for LSSTComCamSim")
-            from lsst.obs.lsst.translators import LsstComCamSimTranslator
-
-            return LsstComCamSimTranslator.compute_detector_exposure_id(exposure_id, detector)
-        elif instrument == "lsstcam":
-            if detector < 0 or detector >= 205:
-                raise ValueError("Invalid detector {detector} for LSSTCam")
-            from lsst.obs.lsst.translators import LsstCamTranslator
-
-            return LsstCamTranslator.compute_detector_exposure_id(exposure_id, detector)
-        else:
-            raise ValueError("Unknown instrument {instrument}")
-
-    @staticmethod
     def compute_flexible_metadata_table_name(instrument: str, obs_type: str) -> str:
         """Compute the name of a flexible metadata table.
 

--- a/python/lsst/summit/utils/utils.py
+++ b/python/lsst/summit/utils/utils.py
@@ -42,6 +42,7 @@ import lsst.afw.math as afwMath
 import lsst.daf.base as dafBase
 import lsst.daf.butler as dafButler
 import lsst.geom as geom
+import lsst.obs.lsst.translators
 import lsst.pipe.base as pipeBase
 import lsst.utils.packages as packageUtils
 from lsst.afw.coord import Weather
@@ -1152,3 +1153,45 @@ def bboxToMatplotlibRectanle(bbox: geom.Box2I | geom.Box2D) -> matplotlib.patche
     ll = bbox.minX, bbox.minY
     width, height = bbox.getDimensions()
     return Rectangle(ll, width, height)
+
+
+def computeExposureId(instrument: str, controller: str, dayObs: int, seqNum) -> int:
+    instrument = instrument.lower()
+    if instrument == "latiss":
+        return lsst.obs.lsst.translators.LatissTranslator.compute_exposure_id(dayObs, seqNum, controller)
+    elif instrument == "lsstcomcam":
+        return lsst.obs.lsst.translators.LsstComCamTranslator.compute_exposure_id(dayObs, seqNum, controller)
+    elif instrument == "lsstcomcamsim":
+        return lsst.obs.lsst.translators.LsstComCamSimTranslator.compute_exposure_id(
+            dayObs, seqNum, controller
+        )
+    elif instrument == "lsstcam":
+        return lsst.obs.lsst.translators.LsstCamTranslator.compute_exposure_id(dayObs, seqNum, controller)
+    else:
+        raise ValueError("Unknown instrument {instrument}")
+
+
+def computeCcdExposureId(instrument: str, exposureId: int, detector: int) -> int:
+    instrument = instrument.lower()
+    if instrument == "latiss":
+        if detector != 0:
+            raise ValueError("Invalid detector {detector} for LATISS")
+        return lsst.obs.lsst.translators.LatissTranslator.compute_detector_exposure_id(exposureId, detector)
+    elif instrument == "lsstcomcam":
+        if detector < 0 or detector >= 9:
+            raise ValueError("Invalid detector {detector} for LSSTComCam")
+        return lsst.obs.lsst.translators.LsstComCamTranslator.compute_detector_exposure_id(
+            exposureId, detector
+        )
+    elif instrument == "lsstcomcamsim":
+        if detector < 0 or detector >= 9:
+            raise ValueError("Invalid detector {detector} for LSSTComCamSim")
+        return lsst.obs.lsst.translators.LsstComCamSimTranslator.compute_detector_exposure_id(
+            exposureId, detector
+        )
+    elif instrument == "lsstcam":
+        if detector < 0 or detector >= 205:
+            raise ValueError("Invalid detector {detector} for LSSTCam")
+        return lsst.obs.lsst.translators.LsstCamTranslator.compute_detector_exposure_id(exposureId, detector)
+    else:
+        raise ValueError("Unknown instrument {instrument}")


### PR DESCRIPTION
compute_exposure_id and compute_ccdexposure_id generate unique numeric ids locally without a server round-trip, since summit_utils already depends on afw.

compute_fixed_metadata_namespace is useful for generating query strings.

insert_multiple allows many rows to be inserted at once (e.g. for many detectors in a focal plane).