### PR TITLE
DM-47874: Use new timestamps in TMA tracking errors

### DIFF
--- a/python/lsst/summit/utils/tmaUtils.py
+++ b/python/lsst/summit/utils/tmaUtils.py
@@ -39,6 +39,7 @@ import pandas as pd
 from astropy.time import Time
 from matplotlib.ticker import FuncFormatter
 from scipy.optimize import minimize
+
 from lsst.utils.iteration import ensure_iterable
 
 from .blockUtils import BlockParser

--- a/python/lsst/summit/utils/tmaUtils.py
+++ b/python/lsst/summit/utils/tmaUtils.py
@@ -216,14 +216,13 @@ def getAzimuthElevationDataForEvent(
         raiseIfTopicNotInSchema=False,
     )
 
-
     azValues = azimuthData["actualPosition"].to_numpy()
     azValTimes = azimuthData["actualPositionTimestamp"].to_numpy()
-    azDemand = azimuthData["demandPosition"].to_numpy()    
+    azDemand = azimuthData["demandPosition"].to_numpy()
     azDemTimes = azimuthData["demandPositionTimestamp"].to_numpy()
     elValues = elevationData["actualPosition"].to_numpy()
     elValTimes = elevationData["actualPositionTimestamp"].to_numpy()
-    elDemand = elevationData["demandPosition"].to_numpy()    
+    elDemand = elevationData["demandPosition"].to_numpy()
     elDemTimes = elevationData["demandPositionTimestamp"].to_numpy()
 
     # Calculate the deltaT needed to drive the median(error) to zero
@@ -232,7 +231,7 @@ def getAzimuthElevationDataForEvent(
     result = minimize(calcDeltaT, x0, args=args, method='Powell',
                       bounds=[(-maxDeltaT, maxDeltaT)])
     deltaTAz = result.x[0]
-    
+
     args = [elValues, elValTimes, elDemand, elDemTimes]
     x0 = [0.0]
     result = minimize(calcDeltaT, x0, args=args, method='Powell',
@@ -249,7 +248,6 @@ def getAzimuthElevationDataForEvent(
     elevationData["elError"] = elError
 
     return azimuthData, elevationData
-
 
 def getM1M3HardpointDataForEvent(
     client: EfdClient,

--- a/python/lsst/summit/utils/tmaUtils.py
+++ b/python/lsst/summit/utils/tmaUtils.py
@@ -36,10 +36,9 @@ import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
-from scipy.optimize import minimize
 from astropy.time import Time
 from matplotlib.ticker import FuncFormatter
-
+from scipy.optimize import minimize
 from lsst.utils.iteration import ensure_iterable
 
 from .blockUtils import BlockParser
@@ -248,6 +247,7 @@ def getAzimuthElevationDataForEvent(
     elevationData["elError"] = elError
 
     return azimuthData, elevationData
+
 
 def getM1M3HardpointDataForEvent(
     client: EfdClient,

--- a/python/lsst/summit/utils/tmaUtils.py
+++ b/python/lsst/summit/utils/tmaUtils.py
@@ -216,14 +216,14 @@ def getAzimuthElevationDataForEvent(
         raiseIfTopicNotInSchema=False,
     )
 
-    azValues = azimuthData["actualPosition"].to_numpy()
-    azValTimes = azimuthData["actualPositionTimestamp"].to_numpy()
-    azDemand = azimuthData["demandPosition"].to_numpy()
-    azDemTimes = azimuthData["demandPositionTimestamp"].to_numpy()
-    elValues = elevationData["actualPosition"].to_numpy()
-    elValTimes = elevationData["actualPositionTimestamp"].to_numpy()
-    elDemand = elevationData["demandPosition"].to_numpy()
-    elDemTimes = elevationData["demandPositionTimestamp"].to_numpy()
+    azValues = np.asarray(azimuthData["actualPosition"])
+    azValTimes = np.asarray(azimuthData["actualPositionTimestamp"])
+    azDemand = np.asarray(azimuthData["demandPosition"])
+    azDemTimes = np.asarray(azimuthData["demandPositionTimestamp"])
+    elValues = np.asarray(elevationData["actualPosition"])
+    elValTimes = np.asarray(elevationData["actualPositionTimestamp"])
+    elDemand = np.asarray(elevationData["demandPosition"])
+    elDemTimes = np.asarray(elevationData["demandPositionTimestamp"])
 
     # Calculate the deltaT needed to drive the median(error) to zero
     args = [azValues, azValTimes, azDemand, azDemTimes]

--- a/python/lsst/summit/utils/tmaUtils.py
+++ b/python/lsst/summit/utils/tmaUtils.py
@@ -154,7 +154,7 @@ def getAzimuthElevationDataForEvent(
     event: TMAEvent,
     prePadding: float = 0,
     postPadding: float = 0,
-    maxDeltaT: float = 1.0E-3,
+    maxDeltaT: float = 1.0e-3,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
     """Get the data for the az/el telemetry topics for a given TMAEvent.
 
@@ -228,14 +228,12 @@ def getAzimuthElevationDataForEvent(
     # Calculate the deltaT needed to drive the median(error) to zero
     args = [azValues, azValTimes, azDemand, azDemTimes]
     x0 = [0.0]
-    result = minimize(calcDeltaT, x0, args=args, method='Powell',
-                      bounds=[(-maxDeltaT, maxDeltaT)])
+    result = minimize(calcDeltaT, x0, args=args, method="Powell", bounds=[(-maxDeltaT, maxDeltaT)])
     deltaTAz = result.x[0]
 
     args = [elValues, elValTimes, elDemand, elDemTimes]
     x0 = [0.0]
-    result = minimize(calcDeltaT, x0, args=args, method='Powell',
-                      bounds=[(-maxDeltaT, maxDeltaT)])
+    result = minimize(calcDeltaT, x0, args=args, method="Powell", bounds=[(-maxDeltaT, maxDeltaT)])
     deltaTEl = result.x[0]
 
     azDemandInterp = np.interp(azValTimes, azDemTimes + deltaTAz, azDemand)


### PR DESCRIPTION
There has been an ongoing problem with single point errors in the TMA data stream.  These are explained in more detail in chapter “Single point errors in the tracking data stream” of [TMA tracking jitter and settling time analysis](https://sitcomtn-112.lsst.io/)  .  Julen of Tekniker has now added additional time stamps so that each data stream has it’s own timestamp.  This should eliminate those errors.  This ticket will implement the use of those new timestamps in the RubinTV tracking error plots, which should eliminat the need for the filterBadValues code.