### PR TITLE
DM-50185 Handle the case where no rows are returned in ConsDbClient.

### DIFF
--- a/python/lsst/summit/utils/consdbClient.py
+++ b/python/lsst/summit/utils/consdbClient.py
@@ -602,10 +602,18 @@ class ConsDbClient:
         url = _urljoin(self.url, "query")
         data = {"query": query}
         result = self._handle_post(url, data).json()
-        if "columns" not in result:
-            # No result rows
+
+        columns = result.get("columns", [])
+        if not columns:
+            # No result columns
             return Table(rows=[])
-        return Table(rows=result["data"], names=result["columns"])
+
+        rows = result.get("data", [])
+        if not rows:
+            # No result rows
+            return Table(names=columns)
+
+        return Table(rows=rows, names=columns)
 
     def schema(
         self, instrument: str | None = None, table: str | None = None


### PR DESCRIPTION
Handle empty result sets gracefully in ConsDbClient.query by returning an empty astropy.table.Table with the correct column names when no data is present. The current implementation of ConsDbClient.query (and other similar) raises a ValueError when the query result contains no rows, due to a mismatch between the number of column names and data columns passed to astropy.table.Table. This occurs because an empty list of rows is provided, while names may still contain column names.