### PR TITLE
DM-50939: Eliminate the need to filterBadValues

### DIFF
--- a/python/lsst/summit/utils/simonyi/mountAnalysis.py
+++ b/python/lsst/summit/utils/simonyi/mountAnalysis.py
@@ -86,7 +86,7 @@ def calculateMountErrors(
     expRecord: DimensionRecord,
     client: EfdClient,
     maxDelta=0.1,
-    doFilterResiduals=True,
+    doFilterResiduals=False,
 ) -> tuple[MountErrors, MountData] | tuple[None, None]:
     """Queries EFD for a given exposure and calculates the RMS errors in the
     axes during the exposure, optionally plotting and saving the data.


### PR DESCRIPTION
DM47874 added new timestamps to TMA tracking errors in the RubinTV TMA channel.  This eliminated the need to filter out bad values. This ticket does the same for the Mount torques plots in the LSSTCam channel.  These plots are still showing filtered values.