### PR TITLE
DM-51096: Use toy pointing model to calculate mount error

### DIFF
--- a/python/lsst/summit/utils/simonyi/mountAnalysis.py
+++ b/python/lsst/summit/utils/simonyi/mountAnalysis.py
@@ -156,6 +156,10 @@ def calculateMountErrors(
     azLinearError = (azValues - azModelValues) * 3600
     azLinearRms = np.sqrt(np.mean(azLinearError * azLinearError))
     if azLinearRms > usePointingModelResidualsAboveAzEl:
+        logger.warning(
+            f"Azimuth pointing model RMS error {azLinearRms:.3f} arcsec is above threshold of "
+            f"{usePointingModelResidualsAboveAzEl:.3f} arcsec, replacing azimuth errors with linear error."
+        )
         # If linear error is large, replace demand errors with linear error
         azimuthData["azError"] = azLinearError
 
@@ -170,6 +174,10 @@ def calculateMountErrors(
     elLinearError = (elValues - elModelValues) * 3600
     elLinearRms = np.sqrt(np.mean(elLinearError * elLinearError))
     if elLinearRms > usePointingModelResidualsAboveAzEl:
+        logger.warning(
+            f"Elevation pointing model RMS error {azLinearRms:.3f} arcsec is above threshold of "
+            f"{usePointingModelResidualsAboveAzEl:.3f} arcsec, replacing elevation errors with linear error."
+        )
         # If linear error is large, replace demand errors with linear error
         elevationData["elError"] = elLinearError
 
@@ -184,6 +192,10 @@ def calculateMountErrors(
     rotLinearError = (rotValues - rotModelValues) * 3600
     rotLinearRms = np.sqrt(np.mean(rotLinearError * rotLinearError))
     if rotLinearRms > usePointingModelResidualsAboveRot:
+        logger.warning(
+            f"Rotation pointing model RMS error {azLinearRms:.3f} arcsec is above threshold of "
+            f"{usePointingModelResidualsAboveAzEl:.3f} arcsec, replacing rotation errors with linear error."
+        )
         # If linear error is large, replace demand errors with linear error
         rotationData["rotError"] = rotLinearError
 

--- a/python/lsst/summit/utils/simonyi/mountAnalysis.py
+++ b/python/lsst/summit/utils/simonyi/mountAnalysis.py
@@ -202,13 +202,13 @@ def calculateMountErrors(
     imageImpactRms = np.sqrt(imageAzRms**2 + imageElRms**2 + imageRotRms**2)
 
     mountErrors = MountErrors(
-        azRms=azRms,
-        elRms=elRms,
-        rotRms=rotRms,
-        imageAzRms=imageAzRms,
-        imageElRms=imageElRms,
-        imageRotRms=imageRotRms,
-        imageImpactRms=imageImpactRms,
+        azRms=float(azRms),
+        elRms=float(elRms),
+        rotRms=float(rotRms),
+        imageAzRms=float(imageAzRms),
+        imageElRms=float(imageElRms),
+        imageRotRms=float(imageRotRms),
+        imageImpactRms=float(imageImpactRms),
         residualFiltering=doFilterResiduals,
         nReplacedAz=nReplacedAz,
         nReplacedEl=nReplacedEl,


### PR DESCRIPTION
There have been several recent exposures where the images were obviously streaked, but the RubinTV Mount Torque plots reported no issue.  This is because the difference between the demand position and the actual position was small because the demand position was not doing what it should.  Examples are 2025051900417, where the mount was not tracking, and 2025052000321, where the rotator was still moving rapidly during the exposure.  Plots and images attached.  In both cases the Mount motion image degradation reported a small value even though the images were unacceptable.  The idea is to install a simplified MTPtg model in the mount analysis code in summit_utils to try and flag these.  This code seems to do that.