### PR TITLE
DM-51845: Fix azimuth wrapping issue

### DIFF
--- a/python/lsst/summit/utils/simonyi/mountAnalysis.py
+++ b/python/lsst/summit/utils/simonyi/mountAnalysis.py
@@ -667,7 +667,10 @@ def getAltAzOverPeriod(
     altAzFrame = AltAz(obstime=times, location=SIMONYI_LOCATION)
     targetAltAz = target.transform_to(altAzFrame)
     az = targetAltAz.az
-    az_wrapped = az.wrap_at(180 * u.deg)
+    if abs(az[0].degree) < 90.0:
+        az_wrapped = az.wrap_at(180.0 * u.deg)
+    else:
+        az_wrapped = az.wrap_at(0.0 * u.deg)
     return az_wrapped.degree, targetAltAz.alt.degree
 
 


### PR DESCRIPTION
Here's the failure and the same image after the fix.  I ran many images at a variety of azimuths, and I think it is fixed now.
<img width="1212" height="847" alt="lsstcam_mount_2025-07-15_000143" src="https://github.com/user-attachments/assets/5dad8d22-7ba1-43ee-adb3-de5742674b7f" />
<img width="1207" height="847" alt="Mount_Plot_Hex_2025071500143" src="https://github.com/user-attachments/assets/48e2a00b-b490-4cc2-be5b-c6438b1bb7fa" />
