### PR TITLE
Fix FootprintSet STDEV detection failure in runSourceDetection

### DIFF
--- a/python/lsst/summit/utils/guiders/detection.py
+++ b/python/lsst/summit/utils/guiders/detection.py
@@ -277,7 +277,7 @@ def runSourceDetection(
     cutOutSize: int = 25,
     apertureRadius: int = 5,
     gain: float = 1.0,
-    starMaskThreshold: float = 20000.0,
+    nPixMin: int = 10,
 ) -> pd.DataFrame:
     """
     Detect sources in an image and measure their properties.
@@ -294,9 +294,8 @@ def runSourceDetection(
         Aperture radius in pixels for photometry.
     gain : `float`
         Detector gain (e-/ADU).
-    starMaskThreshold : `float`
-        Pixel count threshold for masking bright stars when computing the
-        background standard deviation. Pixels above this value are excluded.
+    nPixMin : `int`
+        Minimum number of pixels in a footprint for detection.
 
     Returns
     -------
@@ -307,29 +306,22 @@ def runSourceDetection(
     exposure = ExposureF(MaskedImageF(ImageF(image)))
 
     # Step 2: Detect sources
-    # We use Threshold.VALUE with np.std() instead of Threshold.STDEV because
-    # STDEV uses STDEVCLIP internally which can return 0 for some guider
+    # We use Threshold.VALUE with a sigma68 background estimate instead of
+    # Threshold.STDEV because STDEVCLIP can return 0 for some guider
     # images, causing FootprintSet to fail with "St. dev. must be > 0".
+    # sigma68 = (p84 - p16) / 2 is robust to bright stars (they only
+    # affect the upper tail) and doesn't fail on flat-background images
+    # the way MAD does (MAD=0 when >50% of pixels are identical).
     footprints = None
     if not isBlankImage(image):
-        median = np.nanmedian(exposure.image.array)
-        exposure.image -= median
-        # Mask bright stars when computing std to get background noise estimate
-        bgPixels = exposure.image.array[exposure.image.array < starMaskThreshold]
-        if len(bgPixels) == 0:
-            raise ValueError(
-                f"No pixels below starMaskThreshold={starMaskThreshold}. "
-                "All pixels are saturated or threshold is too low."
-            )
-        imageStd = np.std(bgPixels)
+        p16, median, p84 = np.nanpercentile(image, [16, 50, 84])
+        imageStd = (p84 - p16) / 2.0
         if imageStd <= 0:
-            raise ValueError(
-                f"Background standard deviation is {imageStd}. "
-                "Image may be flat or starMaskThreshold may need adjustment."
-            )
+            return pd.DataFrame(columns=DEFAULT_COLUMNS)
+        exposure.image -= median
         absThreshold = threshold * imageStd
         thresh = afwDetect.Threshold(absThreshold, afwDetect.Threshold.VALUE)
-        footprints = afwDetect.FootprintSet(exposure.getMaskedImage(), thresh, "DETECTED", 10)
+        footprints = afwDetect.FootprintSet(exposure.getMaskedImage(), thresh, "DETECTED", nPixMin)
         exposure.image += median
 
     if not footprints:

--- a/python/lsst/summit/utils/guiders/detection.py
+++ b/python/lsst/summit/utils/guiders/detection.py
@@ -39,6 +39,7 @@ from astropy.stats import sigma_clipped_stats
 
 import lsst.afw.detection as afwDetect
 from lsst.afw.image import ExposureF, ImageF, MaskedImageF
+from lsst.afw.math import STDEVCLIP, makeStatistics
 
 from .reading import GuiderData
 
@@ -305,20 +306,22 @@ def runSourceDetection(
     # Step 1: Convert numpy image to MaskedImage and Exposure
     exposure = ExposureF(MaskedImageF(ImageF(image)))
 
-    # Step 2: Detect sources
-    # We use Threshold.VALUE with a sigma68 background estimate instead of
-    # Threshold.STDEV because STDEVCLIP can return 0 for some guider
-    # images, causing FootprintSet to fail with "St. dev. must be > 0".
-    # sigma68 = (p84 - p16) / 2 is robust to bright stars (they only
-    # affect the upper tail) and doesn't fail on flat-background images
-    # the way MAD does (MAD=0 when >50% of pixels are identical).
+    # Step 2: Detect sources using STDEVCLIP for the background noise.
+    # The input coadd images are dithered (see GuiderData.getStampArrayCoadd)
+    # to prevent integer quantization from collapsing the pixel distribution
+    # and causing STDEVCLIP to return 0. (See DM-54263.)
     footprints = None
     if not isBlankImage(image):
-        p16, median, p84 = np.nanpercentile(image, [16, 50, 84])
-        imageStd = (p84 - p16) / 2.0
-        if imageStd <= 0:
-            return pd.DataFrame(columns=DEFAULT_COLUMNS)
+        median = np.nanmedian(image)
         exposure.image -= median
+        imageStd = float(makeStatistics(exposure.getMaskedImage(), STDEVCLIP).getValue(STDEVCLIP))
+        if imageStd <= 0:
+            # Fallback: sigma68 is robust to quantization and bright stars.
+            p16, p84 = np.nanpercentile(image, [16, 84])
+            imageStd = (p84 - p16) / 2.0
+        if imageStd <= 0:
+            exposure.image += median
+            return pd.DataFrame(columns=DEFAULT_COLUMNS)
         absThreshold = threshold * imageStd
         thresh = afwDetect.Threshold(absThreshold, afwDetect.Threshold.VALUE)
         footprints = afwDetect.FootprintSet(exposure.getMaskedImage(), thresh, "DETECTED", nPixMin)
@@ -627,7 +630,6 @@ def buildReferenceCatalog(
         apertureRadius = int(config.aperSizeArcsec / pixelScale)
 
         array = guiderData.getStampArrayCoadd(guiderName)
-        # array = np.where(array < 0, 0, array)  # Ensure no negative values
         array = array - np.nanmin(array)  # Ensure no negative values
         sources = runSourceDetection(
             array,

--- a/python/lsst/summit/utils/guiders/detection.py
+++ b/python/lsst/summit/utils/guiders/detection.py
@@ -37,8 +37,8 @@ import pandas as pd
 from astropy.nddata import Cutout2D
 from astropy.stats import sigma_clipped_stats
 
+import lsst.afw.detection as afwDetect
 from lsst.afw.image import ExposureF, ImageF, MaskedImageF
-from lsst.summit.utils.utils import detectObjectsInExp
 
 from .reading import GuiderData
 
@@ -277,6 +277,7 @@ def runSourceDetection(
     cutOutSize: int = 25,
     apertureRadius: int = 5,
     gain: float = 1.0,
+    starMaskThreshold: float = 20000.0,
 ) -> pd.DataFrame:
     """
     Detect sources in an image and measure their properties.
@@ -293,6 +294,9 @@ def runSourceDetection(
         Aperture radius in pixels for photometry.
     gain : `float`
         Detector gain (e-/ADU).
+    starMaskThreshold : `float`
+        Pixel count threshold for masking bright stars when computing the
+        background standard deviation. Pixels above this value are excluded.
 
     Returns
     -------
@@ -303,12 +307,30 @@ def runSourceDetection(
     exposure = ExposureF(MaskedImageF(ImageF(image)))
 
     # Step 2: Detect sources
-    # we assume that we have bright stars
-    # filter out stamps with no stars
+    # We use Threshold.VALUE with np.std() instead of Threshold.STDEV because
+    # STDEV uses STDEVCLIP internally which can return 0 for some guider
+    # images, causing FootprintSet to fail with "St. dev. must be > 0".
+    footprints = None
     if not isBlankImage(image):
-        footprints = detectObjectsInExp(exposure, nSigma=threshold)
-    else:
-        footprints = None
+        median = np.nanmedian(exposure.image.array)
+        exposure.image -= median
+        # Mask bright stars when computing std to get background noise estimate
+        bgPixels = exposure.image.array[exposure.image.array < starMaskThreshold]
+        if len(bgPixels) == 0:
+            raise ValueError(
+                f"No pixels below starMaskThreshold={starMaskThreshold}. "
+                "All pixels are saturated or threshold is too low."
+            )
+        imageStd = np.std(bgPixels)
+        if imageStd <= 0:
+            raise ValueError(
+                f"Background standard deviation is {imageStd}. "
+                "Image may be flat or starMaskThreshold may need adjustment."
+            )
+        absThreshold = threshold * imageStd
+        thresh = afwDetect.Threshold(absThreshold, afwDetect.Threshold.VALUE)
+        footprints = afwDetect.FootprintSet(exposure.getMaskedImage(), thresh, "DETECTED", 10)
+        exposure.image += median
 
     if not footprints:
         return pd.DataFrame(columns=DEFAULT_COLUMNS)

--- a/python/lsst/summit/utils/guiders/reading.py
+++ b/python/lsst/summit/utils/guiders/reading.py
@@ -406,10 +406,15 @@ class GuiderData(BaseModel):
         if len(stamps) == 0:
             raise ValueError(f"No stamps found for detector {detName!r}")
 
-        # Collect arrays, with optional bias subtraction
+        # Collect arrays, with optional bias subtraction.
         arrList = [self[detName, idx] for idx in range(len(stamps))]
-        stack = np.nanmedian(arrList, axis=0)
-        return stack
+        # Add a uniform [0, 1) dither per stamp before the median to break
+        # integer quantization. Without this, the coadd pixel distribution
+        # can be so narrow that STDEVCLIP returns 0. (See DM-54263.)
+        stack = np.array(arrList, dtype=np.float32)
+        rng = np.random.default_rng(seed=0)
+        stack += rng.uniform(0, 1, size=stack.shape).astype(np.float32)
+        return np.nanmedian(stack, axis=0)
 
     def getGuiderAmpName(self, detName: str) -> str:
         """

--- a/python/lsst/summit/utils/utils.py
+++ b/python/lsst/summit/utils/utils.py
@@ -488,8 +488,8 @@ def _getAltAzZenithsFromSeqNum(
     for seqNum in seqNumList:
         md = butler.get("raw.metadata", day_obs=dayObs, seq_num=seqNum, detector=0)
         obsInfo = ObservationInfo(md)
-        alt = obsInfo.altaz_begin.alt.value
-        az = obsInfo.altaz_begin.az.value
+        alt = obsInfo.altaz_begin.alt.value  # type: ignore[union-attr]
+        az = obsInfo.altaz_begin.az.value  # type: ignore[union-attr]
         elevations.append(alt)
         zeniths.append(90 - alt)
         azimuths.append(az)

--- a/python/lsst/summit/utils/utils.py
+++ b/python/lsst/summit/utils/utils.py
@@ -488,8 +488,9 @@ def _getAltAzZenithsFromSeqNum(
     for seqNum in seqNumList:
         md = butler.get("raw.metadata", day_obs=dayObs, seq_num=seqNum, detector=0)
         obsInfo = ObservationInfo(md)
-        alt = obsInfo.altaz_begin.alt.value  # type: ignore[union-attr]
-        az = obsInfo.altaz_begin.az.value  # type: ignore[union-attr]
+        assert obsInfo.altaz_begin is not None, f"altaz_begin is None for seqNum={seqNum}"
+        alt = obsInfo.altaz_begin.alt.value
+        az = obsInfo.altaz_begin.az.value
         elevations.append(alt)
         zeniths.append(90 - alt)
         azimuths.append(az)


### PR DESCRIPTION
  ## Summary
  - Add uniform [0, 1) random dither per stamp before median coadd to break integer
  quantization, preventing STDEVCLIP from returning 0 (fix suggested by Robert Lupton).
  - Add sigma68 fallback: if STDEVCLIP still returns 0, use (p84 - p16) / 2 as a safety net.
  - Add configurable `nPixMin` parameter for footprint detection (previously hardcoded to 10).

  ## Problem

  `STDEVCLIP` (from `lsst.afw.math`) returns 0 on some guider coadd images, causing
  `FootprintSet` to crash with `InvalidParameterError: 'St. dev. must be > 0: 0'`.

  Root cause: the guider coadd is a median stack of ~130 stamps. This averages the noise down
  so much that the pixel distribution becomes extremely narrow — many pixels land in the same
  quantized bin. When STDEVCLIP iterates, the first-pass sigma is near zero, the clipping
  range collapses, and it converges to std=0.

  ## Validation

  Full validation on night 2026-02-22: 447 sequences (255 previously failing + 192 passing
  control), excluding 24 with DatasetNotFoundError.

  **STDEVCLIP fix:** The dither fix eliminates all STDEVCLIP=0 cases. Before: 437/2040 (21.4%)
   guider measurements hit STDEVCLIP=0 on failing images, and 25/1536 (1.6%) on passing
  images. After: 0 across all 3576 measurements. The sigma68 fallback was never triggered,
  confirming the dither alone is sufficient.

  **Star recovery:** On the 255 previously failing sequences, the new code recovers a median
  of 7 stars per sequence (was 0). On the 192 control sequences, star counts are stable: 153
  unchanged, 32 improved, 7 lose 1–2 stars due to GalSim `FindAdaptiveMom` convergence
  failures (not related to this fix, tracked in DM-54305).

  | Stage | Stars | Possible | Rate |
  |-------|-------|----------|------|
  | Old pipeline | 1345 | 3576 | 37.6% |
  | + DM-54263 (this PR) | 3144 | 3576 | 87.9% |