### PR TITLE
OSW-2391: Add support in ConsDbClient to insert by (day_obs, seq_num, detector)

### DIFF
--- a/python/lsst/summit/utils/consdbClient.py
+++ b/python/lsst/summit/utils/consdbClient.py
@@ -481,7 +481,7 @@ class ConsDbClient:
         self,
         instrument: str,
         table: str,
-        obs_id: tuple[int, int] | int,
+        obs_id: tuple[int, int] | tuple[int, int, int] | int,
         values: Mapping[str, Any],
         *,
         allow_update: bool = False,
@@ -495,8 +495,18 @@ class ConsDbClient:
             Name of the instrument (e.g. ``LATISS``).
         table : `str`
             Name of the table to insert into.
-        obs_id : `tuple` [ `int`, `int`] or `int`
-            Unique observation id or day_obs and seq_num.
+        obs_id : `tuple`[`int`, `int`] | `tuple`[`int`, `int`, `int`] | `int`
+            How to address the row to insert:
+
+            - `int`: the natural observation id (e.g. ``exposure_id``,
+              ``ccdexposure_id``), targeting the ``.../obs/{obs_id}``
+              endpoint.
+            - 2-tuple ``(day_obs, seq_num)``: targeting the
+              ``.../by_seq_num/{day_obs}/{seq_num}`` endpoint, for
+              exposure-level tables.
+            - 3-tuple ``(day_obs, seq_num, detector)``: targeting the
+              ``.../by_seq_num/{day_obs}/{seq_num}/{detector}`` endpoint,
+              for ccdexposure-level (per-detector) tables.
         values : `Mapping` [ `str`, `Any` ]
             Dictionary-like mapping of column/value pairs to add for the
             observation.
@@ -526,6 +536,11 @@ class ConsDbClient:
 
         data: dict[str, Any]
         if isinstance(obs_id, tuple):
+            assert len(obs_id) in (
+                2,
+                3,
+            ), f"obs_id tuple must be (day_obs, seq_num) or (day_obs, seq_num, detector); got {obs_id!r}"
+
             data = {"table": table, "values": merged_values}
             url = _urljoin(
                 self.url,
@@ -533,8 +548,9 @@ class ConsDbClient:
                 quote(instrument),
                 quote(table),
                 "by_seq_num",
-                quote(str(obs_id[0])),
-                quote(str(obs_id[1])),
+                # Two segments for exposure-level tables, three when a
+                # detector is supplied for ccdexposure-level tables.
+                *(quote(str(part)) for part in obs_id),
             )
         else:
             data = {"table": table, "obs_id": obs_id, "values": merged_values}

--- a/tests/test_consdbClient.py
+++ b/tests/test_consdbClient.py
@@ -202,7 +202,83 @@ def test_client(client):
     assert "clean_url" in str(client.session.hooks["response"])
 
 
+@responses.activate
+def test_insert_obs_id(client):
+    """An integer obs_id targets the ``.../obs/{obs_id}`` endpoint."""
+    responses.post(
+        "http://example.com/consdb/insert/latiss/exposure/obs/271828",
+        json={"message": "Data inserted"},
+        match=[
+            responses.matchers.json_params_matcher(
+                {"table": "exposure", "obs_id": 271828, "values": {"foo": 1}}
+            ),
+        ],
+    )
+    assert client.insert("latiss", "exposure", 271828, {"foo": 1}).json()["message"] == "Data inserted"
+
+
+@responses.activate
+def test_insert_by_seq_num(client):
+    """A 2-tuple targets the ``.../{day_obs}/{seq_num}`` endpoint."""
+    responses.post(
+        "http://example.com/consdb/insert/latiss/exposure/by_seq_num/20240603/123",
+        json={"message": "Data inserted"},
+        match=[
+            responses.matchers.json_params_matcher({"table": "exposure", "values": {"foo": 1}}),
+        ],
+    )
+    assert (
+        client.insert("latiss", "exposure", (20240603, 123), {"foo": 1}).json()["message"] == "Data inserted"
+    )
+
+
+@responses.activate
+def test_insert_by_seq_num_detector(client):
+    """A 3-tuple targets the ``.../{day_obs}/{seq_num}/{detector}``
+    endpoint for per-detector (ccdexposure-level) tables."""
+    responses.post(
+        "http://example.com/consdb/insert/lsstcam/ccdexposure/by_seq_num/20240603/123/94",
+        json={"message": "Data inserted"},
+        match=[
+            responses.matchers.json_params_matcher({"table": "ccdexposure", "values": {"foo": 1}}),
+        ],
+    )
+    assert (
+        client.insert("lsstcam", "ccdexposure", (20240603, 123, 94), {"foo": 1}).json()["message"]
+        == "Data inserted"
+    )
+
+
+@responses.activate
+def test_insert_allow_update(client):
+    """allow_update appends ``?u=1`` to upsert against the addressed key."""
+    responses.post(
+        "http://example.com/consdb/insert/lsstcam/ccdexposure/by_seq_num/20240603/123/94?u=1",
+        json={"message": "Data inserted"},
+        match=[responses.matchers.query_param_matcher({"u": "1"})],
+    )
+    assert (
+        client.insert("lsstcam", "ccdexposure", (20240603, 123, 94), {"foo": 1}, allow_update=True).json()[
+            "message"
+        ]
+        == "Data inserted"
+    )
+
+
+def test_insert_bad_obs_id_tuple(client):
+    """A tuple that is not length 2 or 3 is rejected before any request."""
+    with pytest.raises(AssertionError, match="obs_id tuple"):
+        client.insert("latiss", "exposure", (20240603,), {"foo": 1})
+    with pytest.raises(AssertionError, match="obs_id tuple"):
+        client.insert("latiss", "exposure", (20240603, 123, 94, 0), {"foo": 1})
+
+
+def test_insert_no_values(client):
+    """Inserting with no values raises before any request."""
+    with pytest.raises(ValueError, match="No values to insert"):
+        client.insert("latiss", "exposure", 271828, {})
+
+
 # TODO: more POST tests
-#    client.insert(instrument, table, obs_id, values, allow_update)
 #    client.insert_multiple(instrument, table, obs_dict, allow_update)
 #    client.query(query)


### PR DESCRIPTION
This change updates the insert() method for ConsDB client. It changes the method to allow a tuple of 3 integers containing day_obs, seq_num, detector. This allows the method to be used to insert into ccd-level tables using the multi-column primary keys.