### PR TITLE
Changing threshold to use linearModel form 10 arcsec to 100 arcsec.

### DIFF
--- a/python/lsst/summit/utils/simonyi/mountAnalysis.py
+++ b/python/lsst/summit/utils/simonyi/mountAnalysis.py
@@ -104,7 +104,7 @@ def calculateMountErrors(
     client: EfdClient,
     maxDelta: float = 0.1,
     doFilterResiduals: bool = False,
-    useMockPointingModelResidualsAboveAzEl: float = 10.0,
+    useMockPointingModelResidualsAboveAzEl: float = 100.0,
     useMockPointingModelResidualsAboveRot: float = 15.0,
 ) -> tuple[MountErrors, MountData] | tuple[None, None]:
     """Queries the EFD over a given exposure and calculates the RMS errors


### PR DESCRIPTION
Many images are failing with large values of Mount motion image degradation, typically in the 2-10 arcsec range.  I've looked into it and it is caused by more variation than usual in the timestamps from the TMA.  Changing the threshold to use th linearModel from 10" to 100" fixes the problem, and keeps the original intent for the linearModel.  Fixing it properly is a big re-write that I don't have time for right now.  Here are plots from RubinTV last night, and a plot of the same image with the 100" change.
<img width="1205" height="847" alt="lsstcam_mount_2026-06-03_000451" src="https://github.com/user-attachments/assets/5d443110-8662-4d14-8a09-6bae794626f8" />
<img width="1205" height="847" alt="Mount_Plot_Hex_2026060300451" src="https://github.com/user-attachments/assets/d4c37f91-ee8e-4090-b8f8-ad6503fd5688" />
