### PR TITLE
DM-55152: Dedupe columns in getCcdVisitTableForDay

### DIFF
--- a/python/lsst/summit/utils/consdbClient.py
+++ b/python/lsst/summit/utils/consdbClient.py
@@ -740,18 +740,40 @@ def getCcdVisitTableForDay(
     table : `astropy.table.Table`
         The resulting table.
     """
-    extraVisit: str = ", " + ", ".join(f"v.{item}" for item in visitTableItems) if visitTableItems else ""
+    # ``cvq.*`` already pulls in every column of ccdvisit1_quicklook, so any
+    # column we also name explicitly from ccdvisit1/visit1 has to be dropped
+    # from the SELECT when the quicklook table itself already defines it.
+    # ConsDB has been denormalising identity columns (visit_id, detector,
+    # seq_num, ...) onto the quicklook tables, and selecting such a column
+    # twice makes the server return duplicate column names, which astropy then
+    # refuses to build a Table from. getWideQuicklookTableForDay does the same
+    # dedup for the visit1 join.
+    cvqCols = set(client.query("SELECT * FROM cdb_LSSTCam.ccdvisit1_quicklook LIMIT 0").colnames)
+
+    visitItems = ["band", "exp_time", "seq_num", "day_obs", "img_type"]
+    if visitTableItems:
+        visitItems += visitTableItems
+
+    selectClauses = ["cvq.*"]
+    claimed = set(cvqCols)  # cvq.* already provides all of these names
+    for col in ("detector", "visit_id"):
+        if col not in claimed:
+            selectClauses.append(f"cv.{col}")
+            claimed.add(col)
+    for col in visitItems:
+        if col not in claimed:
+            selectClauses.append(f"v.{col}")
+            claimed.add(col)
+
     query = (
-        "SELECT cvq.*, "
-        "cv.detector, cv.visit_id, "
-        f"v.band, v.exp_time, v.seq_num, v.day_obs, v.img_type{extraVisit} "
+        f"SELECT {', '.join(selectClauses)} "
         "FROM cdb_LSSTCam.ccdvisit1_quicklook as cvq, "
         "cdb_LSSTCam.ccdvisit1 as cv, "
         "cdb_LSSTCam.visit1 as v "
     )
     where = f"WHERE cvq.ccdvisit_id=cv.ccdvisit_id and cv.visit_id=v.visit_id and v.day_obs={dayObs}"
     if detectors:
-        where += f" and detector in ({','.join([str(d) for d in detectors])})"
+        where += f" and cv.detector in ({','.join([str(d) for d in detectors])})"
     if withZeropoint:
         where += " and cvq.zero_point is not null"
 

--- a/tests/test_consdbClient.py
+++ b/tests/test_consdbClient.py
@@ -19,11 +19,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import json
+
 import pytest
 import responses
+from astropy.table import Table
 from requests import HTTPError
 
 from lsst.summit.utils import ConsDbClient, FlexibleMetadataInfo
+from lsst.summit.utils.consdbClient import getCcdVisitTableForDay
 
 
 @pytest.fixture
@@ -277,6 +281,66 @@ def test_insert_no_values(client):
     """Inserting with no values raises before any request."""
     with pytest.raises(ValueError, match="No values to insert"):
         client.insert("latiss", "exposure", 271828, {})
+
+
+@responses.activate
+def test_getCcdVisitTableForDay_dedupes_overlapping_columns(client):
+    """Columns already present in ccdvisit1_quicklook must not be re-selected.
+
+    ``cvq.*`` pulls in every column of ccdvisit1_quicklook. As ConsDB
+    denormalises identity columns (visit_id, detector, seq_num, ...) onto the
+    quicklook table, naming those again explicitly from the joined tables makes
+    the server return duplicate column names, which astropy refuses to build a
+    Table from (DM-55152). They must be dropped from the SELECT instead.
+    """
+    url = "http://example.com/consdb/query"
+
+    # First query is the LIMIT 0 schema probe: pretend the quicklook table has
+    # denormalised visit_id, detector and seq_num onto itself.
+    responses.post(
+        url,
+        json={"columns": ["ccdvisit_id", "visit_id", "detector", "seq_num", "psf_sigma"], "data": []},
+    )
+    # Second query is the real data query; its response only has to build
+    # cleanly, the behaviour under test is the SELECT clause that was sent.
+    responses.post(
+        url,
+        json={
+            "columns": ["ccdvisit_id", "visit_id", "detector", "seq_num", "psf_sigma", "band"],
+            "data": [[1, 100, 7, 5, 1.2, "r"]],
+        },
+    )
+
+    table = getCcdVisitTableForDay(client, 20240101)
+    assert isinstance(table, Table)
+
+    # Only inspect the SELECT clause; the WHERE clause legitimately references
+    # cv.visit_id etc. in its join conditions.
+    sentQuery = json.loads(responses.calls[1].request.body)["query"]
+    selectClause = sentQuery.split(" FROM ")[0]
+    # Columns already provided by cvq.* must not be re-selected explicitly...
+    assert "cvq.*" in selectClause
+    assert "cv.visit_id" not in selectClause
+    assert "cv.detector" not in selectClause
+    assert "v.seq_num" not in selectClause
+    # ...but columns the quicklook table lacks must still be pulled from visit1
+    for col in ("v.band", "v.exp_time", "v.day_obs", "v.img_type"):
+        assert col in selectClause
+
+
+@responses.activate
+def test_getCcdVisitTableForDay_keeps_columns_when_no_overlap(client):
+    """When the quicklook table shares no names, every extra is selected."""
+    url = "http://example.com/consdb/query"
+    responses.post(url, json={"columns": ["ccdvisit_id", "psf_sigma"], "data": []})
+    responses.post(url, json={"columns": ["ccdvisit_id", "psf_sigma"], "data": [[1, 1.2]]})
+
+    getCcdVisitTableForDay(client, 20240101)
+
+    sentQuery = json.loads(responses.calls[1].request.body)["query"]
+    selectClause = sentQuery.split(" FROM ")[0]
+    for col in ("cv.detector", "cv.visit_id", "v.band", "v.exp_time", "v.seq_num", "v.day_obs", "v.img_type"):
+        assert col in selectClause
 
 
 # TODO: more POST tests


### PR DESCRIPTION
cvq.* already selects every column of ccdvisit1_quicklook, so naming detector/visit_id/seq_num/etc. again explicitly from the joined ccdvisit1 and visit1 tables produces duplicate column names once ConsDB starts denormalising those identity columns onto the quicklook table. astropy refuses to build a Table from a result set with repeated column names, raising "ValueError: Duplicate column names".

Skip any explicitly-named column the quicklook schema already provides, mirroring the dedup getWideQuicklookTableForDay already does, and qualify the optional detector filter as cv.detector so it stays unambiguous.

Add regression tests covering the overlapping and non-overlapping column cases.