### PR TITLE
DM-55094: Add package version data model and its ConsDB round-trip

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -224,3 +224,10 @@ ignore_errors = True
 
 [mypy-tests.*]
 ignore_errors = True
+
+# The bulk of the test suite predates type-checking and is unannotated, so
+# errors are ignored above. New, fully-annotated test modules opt back in to
+# checking here (more specific section wins over the tests.* wildcard).
+[mypy-tests.test_packageVersions]
+ignore_errors = False
+disallow_untyped_defs = True

--- a/mypy.ini
+++ b/mypy.ini
@@ -5,6 +5,7 @@ warn_unused_configs = False
 warn_redundant_casts = False
 plugins = pydantic.mypy
 enable_error_code = possibly-undefined
+disallow_untyped_defs = True
 
 # Check all of summit_utils...
 [mypy-lsst.summit.utils.*]
@@ -222,12 +223,7 @@ ignore_errors = True
 [mypy-config.*]
 ignore_errors = True
 
-[mypy-tests.*]
-ignore_errors = True
-
-# The bulk of the test suite predates type-checking and is unannotated, so
-# errors are ignored above. New, fully-annotated test modules opt back in to
-# checking here (more specific section wins over the tests.* wildcard).
-[mypy-tests.test_packageVersions]
-ignore_errors = False
-disallow_untyped_defs = True
+# Test modules (named ``test_*`` - the tests/ dir is not a package) are type-
+# checked under the base config above, which requires annotations. The library
+# source is exempted from that requirement by the disallow_untyped_defs = False
+# in the [mypy-lsst.summit.utils.*] section near the top of this file.

--- a/python/lsst/summit/utils/__init__.py
+++ b/python/lsst/summit/utils/__init__.py
@@ -24,6 +24,7 @@ from .butlerUtils import *
 from .consdbClient import *
 from .imageExaminer import *
 from .nightReport import *
+from .packageVersions import *
 from .peekExposure import *
 from .quickLook import *
 from .spectrumExaminer import *

--- a/python/lsst/summit/utils/packageVersions.py
+++ b/python/lsst/summit/utils/packageVersions.py
@@ -1,0 +1,633 @@
+# This file is part of summit_utils.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The science-package version data model, and its ConsDB round-trip.
+
+The Rapid Analysis backend records, for every image it dispatches, the exact
+versions of the handful of science packages that determine the AOS results,
+plus a single overall "version number" - an integer that increments whenever
+the combined set of package versions changes. The mapping from number to
+versions is kept in a small per-instrument JSON registry file, owned and
+written solely by Rapid Analysis.
+
+This module is the public home of that data model. It lives here, rather than
+in the Rapid Analysis package, because most users cannot import Rapid Analysis
+code but do need to consume the data: `PackageVersions` and its
+(de)serialisation define the wire format, and the functions below read and
+write it in its three homes:
+
+- the ConsDB ``package_versions`` JSONB column (pending: see
+  `PACKAGE_VERSIONS_TABLE`), via `writePackageVersionsToConsDb` /
+  `readPackageVersionsFromConsDb`;
+- the on-disk version-number registry, via `resolveVersionNumber` (Rapid
+  Analysis' write path) and `loadPackageVersionRegistry` (everyone else's read
+  path);
+- and, for data taken before the ConsDB column existed,
+  `writeBackdatedPackageVersions` back-fills ConsDB from the registry.
+
+The JSON blob written to ConsDB is::
+
+    {"versions": {"ts_wep": "v17.6.1-alpha", ...}, "version_number": 42}
+
+with ``version_number`` null when it could not be determined. The blob shape is
+pinned by tests in both this package and Rapid Analysis; change it only with a
+migration plan for the rows already written.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "UNKNOWN_VERSION",
+    "UNKNOWN_VERSION_NUMBER",
+    "PACKAGE_VERSIONS_TABLE",
+    "PACKAGE_VERSIONS_COLUMN",
+    "PackageVersions",
+    "getRegistryPath",
+    "loadPackageVersionRegistry",
+    "resolveVersionNumber",
+    "writePackageVersionsToConsDb",
+    "readPackageVersionsFromConsDb",
+    "writeBackdatedPackageVersions",
+]
+
+import datetime
+import hashlib
+import json
+import logging
+import os
+import re
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from .utils import computeExposureId
+
+if TYPE_CHECKING:
+    from .consdbClient import ConsDbClient
+
+_log = logging.getLogger(__name__)
+
+# Sentinel recorded when a package's version genuinely couldn't be determined
+# at processing time. Readers should expect to encounter it.
+UNKNOWN_VERSION = "unknown"
+
+# Sentinel overall version number used when the registry couldn't be reached.
+# Negative so it can never collide with a real (>= 1) number.
+UNKNOWN_VERSION_NUMBER = -1
+
+# The anticipated home of the package-versions JSONB column in ConsDB, as
+# ``cdb_<instrument>.<PACKAGE_VERSIONS_TABLE>.<PACKAGE_VERSIONS_COLUMN>``.
+# The column does not exist yet; these defaults are parameterised on every
+# function that uses them so they can be corrected without code changes if
+# the schema lands elsewhere.
+PACKAGE_VERSIONS_TABLE = "exposure_quicklook"
+PACKAGE_VERSIONS_COLUMN = "package_versions"
+
+# Everything interpolated into raw SQL by readPackageVersionsFromConsDb must
+# look like a plain identifier; anything else is rejected.
+_SQL_IDENTIFIER_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+def _checkIsSqlIdentifier(value: str, description: str) -> None:
+    """Raise if ``value`` is not usable as a bare SQL identifier.
+
+    Parameters
+    ----------
+    value : `str`
+        The value to check.
+    description : `str`
+        What the value is, for the error message, e.g. ``"table name"``.
+    """
+    if not _SQL_IDENTIFIER_RE.match(value):
+        raise ValueError(f"Invalid {description}: {value!r}")
+
+
+@dataclass
+class PackageVersions:
+    """The versions of the tracked science packages at processing time.
+
+    The versions are held in a dict keyed by package name rather than as named
+    fields so that the set of recorded packages can grow without changing the
+    wire format. The overall version number is the single integer rapid
+    analysis assigns to each distinct set of versions (see
+    `resolveVersionNumber`); it is `None` when not known, e.g. for an object
+    built purely from scraped versions before the registry was consulted.
+
+    Parameters
+    ----------
+    versions : `dict` [`str`, `str`]
+        Mapping of package name to version (a git tag/SHA for git checkouts, an
+        installed distribution version for installed packages, or
+        `UNKNOWN_VERSION`).
+    versionNumber : `int`, optional
+        The overall version number for this set of versions.
+    """
+
+    versions: dict[str, str]
+    versionNumber: int | None = None
+
+    def toDict(self) -> dict[str, Any]:
+        """Render as the JSON blob dict stored in the ConsDB column.
+
+        Returns
+        -------
+        blobDict : `dict` [`str`, `Any`]
+            The pinned wire shape: ``{"versions": {...}, "version_number":
+            <int or None>}``. ``version_number`` is always present (null when
+            unknown) so the blob shape is stable for SQL-side consumers.
+        """
+        return {"versions": dict(self.versions), "version_number": self.versionNumber}
+
+    @classmethod
+    def fromDict(cls, blobDict: Mapping[str, Any]) -> PackageVersions:
+        """Build from the JSON blob dict stored in the ConsDB column.
+
+        Parameters
+        ----------
+        blobDict : `Mapping` [`str`, `Any`]
+            The blob, as produced by `toDict`. A missing ``version_number`` key
+            is tolerated (treated as null) so blobs written by a future
+            shape-reduction still parse.
+
+        Returns
+        -------
+        packageVersions : `PackageVersions`
+            The parsed versions.
+
+        Raises
+        ------
+        ValueError
+            Raised if the blob has no ``versions`` key.
+        """
+        if "versions" not in blobDict:
+            raise ValueError(f"Package-version blob has no 'versions' key: {dict(blobDict)!r}")
+        versionNumber = blobDict.get("version_number")
+        return cls(
+            versions=dict(blobDict["versions"]),
+            versionNumber=int(versionNumber) if versionNumber is not None else None,
+        )
+
+    def toJson(self) -> str:
+        """Render as a canonical JSON string.
+
+        Returns
+        -------
+        jsonString : `str`
+            The `toDict` blob serialised with sorted keys, so identical version
+            sets always serialise identically.
+        """
+        return json.dumps(self.toDict(), sort_keys=True)
+
+    @classmethod
+    def fromJson(cls, jsonString: str | bytes) -> PackageVersions:
+        """Build from a JSON string, as produced by `toJson`.
+
+        Parameters
+        ----------
+        jsonString : `str` or `bytes`
+            The JSON document to parse.
+
+        Returns
+        -------
+        packageVersions : `PackageVersions`
+            The parsed versions.
+
+        Raises
+        ------
+        ValueError
+            Raised if the document is not valid JSON, or parses to something
+            other than the expected blob shape.
+        """
+        parsed = json.loads(jsonString)
+        if not isinstance(parsed, dict):
+            raise ValueError(f"Expected a JSON object for a package-version blob, got {type(parsed)}")
+        return cls.fromDict(parsed)
+
+    def versionHash(self) -> str:
+        """A stable, order-independent hash of the package versions.
+
+        Used as the identity of a version set in the registry: two pods with
+        the same package versions hash identically and therefore share an
+        overall version number, regardless of the order the packages happen to
+        be recorded in. ``versionNumber`` is deliberately excluded - the number
+        is *derived from* this hash by `resolveVersionNumber`, so including it
+        would be circular.
+
+        Returns
+        -------
+        hexdigest : `str`
+            The SHA-256 hex digest of the canonicalised versions.
+        """
+        canonical = json.dumps(self.versions, sort_keys=True)
+        return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def getRegistryPath(registryDir: str, instrument: str) -> str:
+    """Build the path to an instrument's overall-version registry file.
+
+    The registry is kept per-instrument: each rapid analysis head node owns the
+    registry for its own instrument, so there is only ever a single writer per
+    file.
+
+    Parameters
+    ----------
+    registryDir : `str`
+        The directory holding the registry files.
+    instrument : `str`
+        The instrument the registry is for, e.g. ``"LSSTCam"``.
+
+    Returns
+    -------
+    registryPath : `str`
+        The path to the registry JSON file.
+    """
+    return os.path.join(registryDir, f"packageVersionRegistry-{instrument}.json")
+
+
+def _loadRegistryEntries(registryPath: str) -> list[dict[str, Any]]:
+    """Load the list of entries from a registry file, or ``[]`` if absent.
+
+    Parameters
+    ----------
+    registryPath : `str`
+        The path to the registry JSON file.
+
+    Returns
+    -------
+    entries : `list` [`dict` [`str`, `Any`]]
+        The registry entries, or an empty list if the file does not exist.
+
+    Raises
+    ------
+    ValueError
+        Raised if the file's ``entries`` value is not a list.
+    """
+    if not os.path.isfile(registryPath):
+        return []
+    with open(registryPath) as f:
+        data = json.load(f)
+    entries = data.get("entries", [])
+    if not isinstance(entries, list):
+        raise ValueError(f"Malformed registry at {registryPath}: 'entries' is not a list")
+    return entries
+
+
+def _saveRegistryEntries(registryPath: str, entries: list[dict[str, Any]]) -> None:
+    """Atomically write the registry entries to ``registryPath``.
+
+    Parameters
+    ----------
+    registryPath : `str`
+        The path to the registry JSON file to write.
+    entries : `list` [`dict` [`str`, `Any`]]
+        The registry entries to write.
+    """
+    directory = os.path.dirname(registryPath)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+    tmpPath = f"{registryPath}.tmp"
+    with open(tmpPath, "w") as f:
+        json.dump({"entries": entries}, f, indent=2, sort_keys=True)
+    os.replace(tmpPath, registryPath)  # atomic, so a concurrent reader never sees a half-written file
+
+
+def loadPackageVersionRegistry(registryPath: str) -> dict[int, PackageVersions]:
+    """Load a version-number registry file from disk.
+
+    This is the read side of the registry the rapid analysis head node writes
+    via `resolveVersionNumber`, mapping each overall version number to the
+    package versions it stands for. Use it (with
+    `writePackageVersionsToConsDb`) to back-fill ConsDB for data processed
+    before the ConsDB column existed - or `writeBackdatedPackageVersions`,
+    which composes the two.
+
+    Unlike the never-raising write path, this raises on any problem: backfill
+    tooling should fail loudly rather than silently write nothing.
+
+    Parameters
+    ----------
+    registryPath : `str`
+        The path to the registry JSON file, e.g. from `getRegistryPath`.
+
+    Returns
+    -------
+    registry : `dict` [`int`, `PackageVersions`]
+        Mapping of overall version number to its package versions, with each
+        `PackageVersions.versionNumber` filled in.
+
+    Raises
+    ------
+    FileNotFoundError
+        Raised if there is no file at ``registryPath``.
+    ValueError
+        Raised if the file does not have the expected registry shape.
+    """
+    if not os.path.isfile(registryPath):
+        raise FileNotFoundError(f"No package-version registry found at {registryPath}")
+    registry: dict[int, PackageVersions] = {}
+    for entry in _loadRegistryEntries(registryPath):
+        try:
+            number = int(entry["number"])
+            versions = dict(entry["versions"])
+        except (KeyError, TypeError, ValueError) as e:
+            raise ValueError(f"Malformed registry entry in {registryPath}: {entry!r}") from e
+        registry[number] = PackageVersions(versions=versions, versionNumber=number)
+    return registry
+
+
+def resolveVersionNumber(
+    registryPath: str,
+    packageVersions: PackageVersions,
+    timestamp: str | None = None,
+    log: logging.Logger | None = None,
+) -> int:
+    """Map a set of package versions to its overall, incrementing number.
+
+    The registry at ``registryPath`` records every distinct package-version set
+    seen so far and the integer assigned to it. If ``packageVersions`` is
+    already known, its existing number is returned. Otherwise it is assigned
+    the next integer (one more than the highest seen), recorded in the
+    registry, and that number returned.
+
+    This is the registry's only write path, called solely by the rapid analysis
+    head node (one process per instrument, hence one writer per file). Robust:
+    any problem reading or writing the registry results in a warning and
+    `UNKNOWN_VERSION_NUMBER`, never an exception - recording an overall number
+    must not be able to disrupt processing.
+
+    Parameters
+    ----------
+    registryPath : `str`
+        The path to the registry JSON file.
+    packageVersions : `PackageVersions`
+        The versions to look up or record. Only ``versions`` is consulted (via
+        `PackageVersions.versionHash`); its ``versionNumber`` is ignored.
+    timestamp : `str`, optional
+        The timestamp recorded against a newly-assigned number. Defaults to the
+        current UTC time; injectable for deterministic tests.
+    log : `logging.Logger`, optional
+        The logger to use. Defaults to this module's logger.
+
+    Returns
+    -------
+    number : `int`
+        The overall version number (``>= 1``), or `UNKNOWN_VERSION_NUMBER` if
+        the registry could not be reached.
+    """
+    if log is None:
+        log = _log
+
+    targetHash = packageVersions.versionHash()
+    try:
+        entries = _loadRegistryEntries(registryPath)
+        for entry in entries:
+            if entry.get("hash") == targetHash:
+                return int(entry["number"])
+
+        nextNumber = max((int(entry["number"]) for entry in entries), default=0) + 1
+        if timestamp is None:
+            timestamp = datetime.datetime.now(datetime.timezone.utc).isoformat()
+        entries.append(
+            {
+                "number": nextNumber,
+                "hash": targetHash,
+                "versions": dict(packageVersions.versions),
+                "firstSeen": timestamp,
+            }
+        )
+        _saveRegistryEntries(registryPath, entries)
+        log.info("Assigned new overall package-version number %d to %s", nextNumber, packageVersions.versions)
+        return nextNumber
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError) as e:
+        log.warning("Could not resolve the overall package-version number at %s: %s", registryPath, e)
+        return UNKNOWN_VERSION_NUMBER
+
+
+def writePackageVersionsToConsDb(
+    client: ConsDbClient,
+    instrument: str,
+    dayObs: int,
+    seqNum: int,
+    packageVersions: PackageVersions,
+    exposureId: int | None = None,
+    controller: str = "O",
+    allowUpdate: bool = True,
+    table: str = PACKAGE_VERSIONS_TABLE,
+    column: str = PACKAGE_VERSIONS_COLUMN,
+) -> None:
+    """Write the package versions for an exposure to ConsDB.
+
+    The `PackageVersions.toDict` blob is written to the JSONB ``column`` of
+    ``cdb_<instrument>.<table>`` for the exposure identified by ``(dayObs,
+    seqNum)``. Raises on failure (e.g. the column not existing yet, or the
+    server rejecting the write) - callers doing bulk backfill should expect and
+    handle that per-row.
+
+    Parameters
+    ----------
+    client : `ConsDbClient`
+        The client used to talk to ConsDB.
+    instrument : `str`
+        The instrument name, e.g. ``"LSSTCam"``.
+    dayObs : `int`
+        The dayObs of the exposure.
+    seqNum : `int`
+        The seqNum of the exposure.
+    packageVersions : `PackageVersions`
+        The versions to write.
+    exposureId : `int`, optional
+        The exposure id. ConsDB requires it in the row values when updating an
+        exposure-level table; computed from ``(instrument, controller, dayObs,
+        seqNum)`` if not supplied.
+    controller : `str`, optional
+        The controller letter used when computing ``exposureId``, e.g. ``"O"``
+        (the OCS, the default) or ``"C"`` (the CCS). Ignored if ``exposureId``
+        is supplied.
+    allowUpdate : `bool`, optional
+        Allow updating an existing row. Defaults to `True` because the target
+        row usually already exists by the time versions are written.
+    table : `str`, optional
+        The table name within the instrument's schema, without the
+        ``cdb_<instrument>.`` prefix. Defaults to `PACKAGE_VERSIONS_TABLE`.
+    column : `str`, optional
+        The JSONB column to write. Defaults to `PACKAGE_VERSIONS_COLUMN`.
+    """
+    _checkIsSqlIdentifier(table, "table name")
+    _checkIsSqlIdentifier(column, "column name")
+    if exposureId is None:
+        exposureId = computeExposureId(instrument, controller, dayObs, seqNum)
+    client.insert(
+        instrument=instrument,
+        table=f"cdb_{instrument.lower()}.{table}",
+        obs_id=(dayObs, seqNum),  # tuple-form required for updating non ccd-type tables
+        values={column: packageVersions.toDict(), "exposure_id": exposureId},
+        allow_update=allowUpdate,
+    )
+
+
+def readPackageVersionsFromConsDb(
+    client: ConsDbClient,
+    instrument: str,
+    dayObs: int,
+    seqNum: int,
+    table: str = PACKAGE_VERSIONS_TABLE,
+    column: str = PACKAGE_VERSIONS_COLUMN,
+) -> PackageVersions | None:
+    """Read the package versions for an exposure back from ConsDB.
+
+    The inverse of `writePackageVersionsToConsDb`. Tolerant of how the JSONB
+    column comes back over the query API: both an already-parsed JSON object
+    and a JSON string are accepted.
+
+    Parameters
+    ----------
+    client : `ConsDbClient`
+        The client used to talk to ConsDB.
+    instrument : `str`
+        The instrument name, e.g. ``"LSSTCam"``.
+    dayObs : `int`
+        The dayObs of the exposure.
+    seqNum : `int`
+        The seqNum of the exposure.
+    table : `str`, optional
+        The table name within the instrument's schema, without the
+        ``cdb_<instrument>.`` prefix. Defaults to `PACKAGE_VERSIONS_TABLE`.
+    column : `str`, optional
+        The JSONB column to read. Defaults to `PACKAGE_VERSIONS_COLUMN`.
+
+    Returns
+    -------
+    packageVersions : `PackageVersions` or `None`
+        The versions recorded for the exposure, or `None` if the exposure has
+        no row in the table or the column is null.
+
+    Raises
+    ------
+    RuntimeError
+        Raised if more than one row matches, which should be impossible.
+    TypeError
+        Raised if the column value is of an unexpected type.
+    """
+    _checkIsSqlIdentifier(instrument, "instrument name")
+    _checkIsSqlIdentifier(table, "table name")
+    _checkIsSqlIdentifier(column, "column name")
+    schemaName = f"cdb_{instrument.lower()}"
+    # Join via the exposure table rather than assuming day_obs/seq_num are
+    # denormalised onto the quicklook table.
+    query = (
+        f"SELECT q.{column} "
+        f"FROM {schemaName}.{table} q "
+        f"JOIN {schemaName}.exposure e ON e.exposure_id = q.exposure_id "
+        f"WHERE e.day_obs = {int(dayObs)} AND e.seq_num = {int(seqNum)}"
+    )
+    result = client.query(query)
+    if len(result) == 0:
+        return None
+    if len(result) > 1:
+        raise RuntimeError(
+            f"Got {len(result)} package-version rows for {instrument} ({dayObs=}, {seqNum=});"
+            " expected at most one"
+        )
+    cell = result[column][0]
+    if cell is None or cell is np.ma.masked:
+        return None
+    if isinstance(cell, (str, bytes)):
+        return PackageVersions.fromJson(cell)
+    if isinstance(cell, Mapping):
+        return PackageVersions.fromDict(cell)
+    raise TypeError(f"Unexpected type for the {column} column: {type(cell)}")
+
+
+def writeBackdatedPackageVersions(
+    client: ConsDbClient,
+    instrument: str,
+    dayObs: int,
+    seqNum: int,
+    versionNumber: int,
+    registryPath: str,
+    exposureId: int | None = None,
+    controller: str = "O",
+    allowUpdate: bool = True,
+) -> PackageVersions:
+    """Back-fill ConsDB with the package versions for an already-taken image.
+
+    For data processed before the ConsDB column existed, where the overall
+    version number used for each image is known: the number is expanded to its
+    full package-version set via the on-disk registry, and the resulting blob
+    written to ConsDB exactly as a live write would have been.
+
+    This re-reads the registry file on every call for simplicity; when
+    back-filling many images, load it once with `loadPackageVersionRegistry`
+    and call `writePackageVersionsToConsDb` per image instead.
+
+    Parameters
+    ----------
+    client : `ConsDbClient`
+        The client used to talk to ConsDB.
+    instrument : `str`
+        The instrument name, e.g. ``"LSSTCam"``.
+    dayObs : `int`
+        The dayObs of the exposure.
+    seqNum : `int`
+        The seqNum of the exposure.
+    versionNumber : `int`
+        The overall version number the image was processed with.
+    registryPath : `str`
+        The path to the registry JSON file mapping version numbers to package
+        versions, e.g. from `getRegistryPath`.
+    exposureId : `int`, optional
+        The exposure id; computed if not supplied, see
+        `writePackageVersionsToConsDb`.
+    controller : `str`, optional
+        The controller letter used when computing ``exposureId``.
+    allowUpdate : `bool`, optional
+        Allow updating an existing row. Defaults to `True`.
+
+    Returns
+    -------
+    packageVersions : `PackageVersions`
+        The versions that were written, as resolved from the registry.
+
+    Raises
+    ------
+    ValueError
+        Raised if ``versionNumber`` is not present in the registry.
+    """
+    registry = loadPackageVersionRegistry(registryPath)
+    packageVersions = registry.get(versionNumber)
+    if packageVersions is None:
+        raise ValueError(
+            f"Version number {versionNumber} is not in the registry at {registryPath};"
+            f" known numbers: {sorted(registry)}"
+        )
+    writePackageVersionsToConsDb(
+        client,
+        instrument,
+        dayObs,
+        seqNum,
+        packageVersions,
+        exposureId=exposureId,
+        controller=controller,
+        allowUpdate=allowUpdate,
+    )
+    return packageVersions

--- a/python/lsst/summit/utils/tmaUtils.py
+++ b/python/lsst/summit/utils/tmaUtils.py
@@ -851,7 +851,7 @@ class TMAEvent:
     duration: float  # seconds
     begin: Time
     end: Time
-    blockInfos: list = field(default_factory=list)
+    blockInfos: list | None = field(default_factory=list)
     version: int = 0  # update this number any time a code change which could change event definitions is made
     _startRow: int
     _endRow: int
@@ -974,7 +974,7 @@ class TMAEvent:
         if blockSeqNum is not None and block is None:
             raise ValueError("block must be specified if blockSeqNum is specified")
 
-        for blockInfo in self.blockInfos:
+        for blockInfo in self.blockInfos or []:
             # "X is None or" is used for each parameter to allow it to be None
             # in the kwargs
             blockMatches = False

--- a/python/lsst/summit/utils/utils.py
+++ b/python/lsst/summit/utils/utils.py
@@ -142,7 +142,7 @@ def countPixels(maskedImage: afwImage.MaskedImage, maskPlane: str) -> int:
     return len(np.where(np.bitwise_and(maskedImage.mask.array, bit))[0])
 
 
-def quickSmooth(data: npt.NDArray[np.float64], sigma: float = 2) -> npt.NDArray[np.float64]:
+def quickSmooth(data: npt.NDArray[np.floating[Any]], sigma: float = 2) -> npt.NDArray[np.floating[Any]]:
     """Perform a quick smoothing of the image.
 
     Not to be used for scientific purposes, but improves the stretch and

--- a/tests/test_bestEffortIsr.py
+++ b/tests/test_bestEffortIsr.py
@@ -29,8 +29,12 @@ from lsst.summit.utils.quickLook import QuickLookIsrTask
 
 
 class BestEffortIsrTestCase(lsst.utils.tests.TestCase):
+    # class attributes populated in setUpClass
+    bestEffortIsr: BestEffortIsr
+    dataId: dict[str, int]
+
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         try:
             cls.bestEffortIsr = BestEffortIsr()
         except (FileNotFoundError, ValueError):
@@ -40,7 +44,7 @@ class BestEffortIsrTestCase(lsst.utils.tests.TestCase):
         # main@USDF - LATISS/raw/all
         cls.dataId = {"day_obs": 20251021, "seq_num": 443, "detector": 0}
 
-    def test_getExposure(self):
+    def test_getExposure(self) -> None:
         # in most locations this will load a pre-made image
         exp = self.bestEffortIsr.getExposure(self.dataId)
         self.assertIsInstance(exp, afwImage.Exposure)
@@ -49,7 +53,7 @@ class BestEffortIsrTestCase(lsst.utils.tests.TestCase):
         exp = self.bestEffortIsr.getExposure(self.dataId, forceRemake=True)
         self.assertIsInstance(exp, afwImage.Exposure)
 
-    def test_getExposureFromExpRecord(self):
+    def test_getExposureFromExpRecord(self) -> None:
         """Test getting with an expRecord. This requires also passing in
         the detector number as a kwarg.
         """
@@ -67,14 +71,14 @@ class BestEffortIsrTestCase(lsst.utils.tests.TestCase):
         exp = self.bestEffortIsr.getExposure(expRecord.dataId, detector=0, forceRemake=True)
         self.assertIsInstance(exp, afwImage.Exposure)
 
-    def test_raises(self):
+    def test_raises(self) -> None:
         """Ensure function cannot be called without specifying a detector."""
         dataId = self.dataId
         dataId.pop("detector")
         with self.assertRaises(ValueError):
             self.bestEffortIsr.getExposure(dataId)
 
-    def test_quicklook_connections(self):
+    def test_quicklook_connections(self) -> None:
         """Test that various QuickLookIsrConnections inputs are no longer
         required.
         """
@@ -88,7 +92,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_bestEffortIsr.py
+++ b/tests/test_bestEffortIsr.py
@@ -83,9 +83,9 @@ class BestEffortIsrTestCase(lsst.utils.tests.TestCase):
         required.
         """
         connections = QuickLookIsrTask.ConfigClass.ConnectionsClass(config=QuickLookIsrTask.ConfigClass())
-        self.assertEqual(connections.bias.minimum, 0)
-        self.assertEqual(connections.flat.minimum, 0)
-        self.assertEqual(connections.ccdExposure.minimum, 1)
+        self.assertEqual(connections.bias.minimum, 0)  # type: ignore[attr-defined]
+        self.assertEqual(connections.flat.minimum, 0)  # type: ignore[attr-defined]
+        self.assertEqual(connections.ccdExposure.minimum, 1)  # type: ignore[attr-defined]
 
 
 class TestMemory(lsst.utils.tests.MemoryTestCase):

--- a/tests/test_blockUtils.py
+++ b/tests/test_blockUtils.py
@@ -143,13 +143,13 @@ class BlockParserTestCase(lsst.utils.tests.TestCase):
     @vcr.use_cassette()
     def test_parsing(self) -> None:
         blockNums = self.blockParser.getBlockNums()
-        self.assertTrue(all(isinstance(n, str)) for n in blockNums)
+        self.assertTrue(all(isinstance(n, str) for n in blockNums))
         self.assertEqual(blockNums, list(self.blockDict.keys()))
 
         for block, seqNums in self.blockDict.items():
             self.assertTrue(isinstance(block, str))
             self.assertIsInstance(seqNums, list)
-            self.assertTrue(all(isinstance(s, int)) for s in seqNums)
+            self.assertTrue(all(isinstance(s, int) for s in seqNums))
 
             found = self.blockParser.getSeqNums(block)
             self.assertTrue(all(isinstance(s, int) for s in found))

--- a/tests/test_blockUtils.py
+++ b/tests/test_blockUtils.py
@@ -25,6 +25,7 @@ import asyncio
 import json
 import os
 import unittest
+from typing import Any
 
 import pandas as pd
 from utils import getVcr
@@ -107,9 +108,18 @@ def writeNewBlockInfoTestTruthValues(dayObs: int) -> None:
 @unittest.skipIf(not HAS_EFD_CLIENT, "No EFD client available")
 @vcr.use_cassette()
 class BlockParserTestCase(lsst.utils.tests.TestCase):
+    # class attributes populated in setUpClass
+    client: Any
+    dayObsNoTestCases: int
+    dayObsWithCases: int
+    dayObsNoBlocks: int
+    blockParser: BlockParser
+    blockNums: list[str]
+    blockDict: dict[str, list[int]]
+
     @classmethod
     @vcr.use_cassette()
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         try:
             cls.client = makeEfdClient(testing=True)
         except RuntimeError:
@@ -125,13 +135,13 @@ class BlockParserTestCase(lsst.utils.tests.TestCase):
             cls.blockDict[block] = cls.blockParser.getSeqNums(block)
 
     @vcr.use_cassette()
-    def tearDown(self):
+    def tearDown(self) -> None:
         loop = asyncio.get_event_loop()
         if self.client.influx_client is not None:
             loop.run_until_complete(self.client.influx_client.close())
 
     @vcr.use_cassette()
-    def test_parsing(self):
+    def test_parsing(self) -> None:
         blockNums = self.blockParser.getBlockNums()
         self.assertTrue(all(isinstance(n, str)) for n in blockNums)
         self.assertEqual(blockNums, list(self.blockDict.keys()))
@@ -154,7 +164,7 @@ class BlockParserTestCase(lsst.utils.tests.TestCase):
                 self.blockParser.printBlockEvolution(block, seqNum=seqNum)
 
     @vcr.use_cassette()
-    def test_notFoundBehavior(self):
+    def test_notFoundBehavior(self) -> None:
         # no block data on this day so check init doesn't raise
         blockParser = BlockParser(dayObs=self.dayObsNoBlocks, client=self.client)
         self.assertIsInstance(blockParser, BlockParser)
@@ -182,7 +192,7 @@ class BlockParserTestCase(lsst.utils.tests.TestCase):
         blockParser.getBlockInfo(block=9999999, seqNum=9999999)
 
     @vcr.use_cassette()
-    def test_actualValues(self):
+    def test_actualValues(self) -> None:
         for dayObs in [self.dayObsNoTestCases, self.dayObsWithCases]:
             data = getBlockInfoTestTruthValues(dayObs)
             blockParser = BlockParser(dayObs, client=self.client)
@@ -205,7 +215,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_blockUtils.py
+++ b/tests/test_blockUtils.py
@@ -201,6 +201,7 @@ class BlockParserTestCase(lsst.utils.tests.TestCase):
                 seqNums = blockParser.getSeqNums(block)
                 for seqNum in seqNums:
                     blockInfo = blockParser.getBlockInfo(block, seqNum)
+                    assert blockInfo is not None
                     line = data[blockInfo.blockNumber, blockInfo.seqNum]
                     items = line.split(f"{DELIMITER}")
                     self.assertEqual(items[0], blockInfo.blockId)

--- a/tests/test_butlerUtils.py
+++ b/tests/test_butlerUtils.py
@@ -24,7 +24,7 @@ import datetime
 import os
 import random
 import unittest
-from typing import Iterable
+from typing import Any, Iterable
 
 import lsst.daf.butler as dafButler
 import lsst.utils.tests
@@ -140,13 +140,13 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
             )
 
     def test_sanitizeDayObs(self) -> None:
-        dayObs = "2020-01-02"
+        dayObs: str | int = "2020-01-02"
         self.assertEqual(sanitizeDayObs(dayObs), 20200102)
         dayObs = 20210201
         self.assertEqual(sanitizeDayObs(dayObs), dayObs)
 
         with self.assertRaises(ValueError):
-            sanitizeDayObs(1.234)
+            sanitizeDayObs(1.234)  # type: ignore[arg-type]
             sanitizeDayObs("Febuary 29th, 1970")
 
     def test_getMostRecentDayObs(self) -> None:
@@ -387,7 +387,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
 
     def test_updateDataId(self) -> None:
         # check with a dataCoordinate
-        dataId = copy.copy(self.expRecordNoDetector.dataId)
+        dataId: Any = copy.copy(self.expRecordNoDetector.dataId)
         self.assertTrue("detector" not in dataId)
         dataId = updateDataId(dataId, detector=123)
         self.assertTrue("detector" in dataId)
@@ -406,6 +406,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         expId = self.expIdOnly["exposure"]
         dayObs = self.dayObsSeqNumIdOnly["day_obs"]
         seqNum = self.dayObsSeqNumIdOnly["seq_num"]
+        assert seqNum is not None
 
         recordByExpId = getExpRecord(self.butler, "LATISS", expId=expId)
         self.assertIsInstance(recordByExpId, dafButler.DimensionRecord)
@@ -438,20 +439,20 @@ class ButlerInitTestCase(lsst.utils.tests.TestCase):
             if "DAF_BUTLER_REPOSITORY_INDEX" in os.environ:  # can't del unless it's already there
                 del os.environ["DAF_BUTLER_REPOSITORY_INDEX"]
             with self.assertRaises(FileNotFoundError):
-                dafButler.Butler("LATISS")
+                dafButler.Butler("LATISS")  # type: ignore[abstract]
 
         # If DAF_BUTLER_REPOSITORY_INDEX is present but is just an empty
         # string then using a label raises a RuntimeError
         with unittest.mock.patch.dict(os.environ, {"DAF_BUTLER_REPOSITORY_INDEX": ""}):
             with self.assertRaises(FileNotFoundError):
-                dafButler.Butler("LATISS")
+                dafButler.Butler("LATISS")  # type: ignore[abstract]
 
         # If DAF_BUTLER_REPOSITORY_INDEX _is_ set, we can't rely on any given
         # camera existing, but we can check that we get the expected error
         # when trying to init an instrument which definitely won't be defined.
         if os.getenv("DAF_BUTLER_REPOSITORY_INDEX"):
             with self.assertRaises(FileNotFoundError):
-                dafButler.Butler("NotAValidCameraName")
+                dafButler.Butler("NotAValidCameraName")  # type: ignore[abstract]
 
     def test_makeDefaultLatissButlerRaiseTypes(self) -> None:
         """makeDefaultLatissButler unifies the mixed exception types from

--- a/tests/test_butlerUtils.py
+++ b/tests/test_butlerUtils.py
@@ -67,7 +67,7 @@ from lsst.summit.utils.butlerUtils import (
 class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
     """A test case for testing sky position offsets for exposures."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         # this also functions as test_makeDefaultLatissButler(), but we may as
         # well catch the butler once it's made so it can be reused if needed,
         # given how hard it is to made it robustly
@@ -114,13 +114,13 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         self.dataCoordMinimal = self.butler.registry.expandDataId(self.rawDataIdNoDayObSeqNum, detector=0)
         self.assertIsInstance(self.dataCoordMinimal, dafButler.DataCoordinate)
 
-    def test_getLatissDefaultCollections(self):
+    def test_getLatissDefaultCollections(self) -> None:
         defaultCollections = getLatissDefaultCollections()
         self.assertTrue(defaultCollections is not None)
         self.assertTrue(defaultCollections != [])
         self.assertTrue(len(defaultCollections) >= 1)
 
-    def test_RECENT_DAY(self):
+    def test_RECENT_DAY(self) -> None:
         todayInt = int(datetime.date.today().strftime("%Y%m%d"))
         self.assertTrue(RECENT_DAY <= todayInt)  # in the past
         self.assertTrue(RECENT_DAY >= 20200101)  # not too far in the past
@@ -139,7 +139,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
                 "You might want to consider updating this to speed up butler queries."
             )
 
-    def test_sanitizeDayObs(self):
+    def test_sanitizeDayObs(self) -> None:
         dayObs = "2020-01-02"
         self.assertEqual(sanitizeDayObs(dayObs), 20200102)
         dayObs = 20210201
@@ -149,7 +149,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
             sanitizeDayObs(1.234)
             sanitizeDayObs("Febuary 29th, 1970")
 
-    def test_getMostRecentDayObs(self):
+    def test_getMostRecentDayObs(self) -> None:
         # just a basic sanity check here as we can't know the value,
         # but at least check something is returned, and is plausible
         recentDay = getMostRecentDayObs(self.butler)
@@ -159,7 +159,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         # the year wouldd be 2XXX+1000, so set to y4k just in case
         self.assertTrue(recentDay < 40000000)
 
-    def test_getSeqNumsForDayObs(self):
+    def test_getSeqNumsForDayObs(self) -> None:
         emptyDay = 19990101
         seqnums = getSeqNumsForDayObs(self.butler, emptyDay)
         self.assertIsInstance(seqnums, Iterable)
@@ -170,7 +170,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         self.assertIsInstance(seqnums, Iterable)
         self.assertTrue(len(list(seqnums)) >= 1)
 
-    def test_getMostRecentDataId(self):
+    def test_getMostRecentDataId(self) -> None:
         # we can't know the values, but it should always return something
         # and the dict and int forms should always have certain keys and agree
         dataId = getMostRecentDataId(self.butler)
@@ -179,7 +179,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         self.assertIn("seq_num", dataId)
         self.assertTrue("exposure" in dataId or "exposure.id" in dataId)
 
-    def test_getDatasetRefForDataId(self):
+    def test_getDatasetRefForDataId(self) -> None:
         dRef = getDatasetRefForDataId(self.butler, "raw", self.rawDataId)
         self.assertIsInstance(dRef, DatasetRef)
 
@@ -188,7 +188,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         dRef = getDatasetRefForDataId(self.butler, "raw", self.dataCoordMinimal)
         self.assertIsInstance(dRef, DatasetRef)
 
-    def test__dayobs_present(self):
+    def test__dayobs_present(self) -> None:
         goods = [{"day_obs": 123}, {"exposure.day_obs": 234}, {"day_obs": 345, "otherkey": -1}]
         bads = [{"different_key": 123}]
         for good in goods:
@@ -196,7 +196,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         for bad in bads:
             self.assertFalse(_dayobs_present(bad))
 
-    def test__seqnum_present(self):
+    def test__seqnum_present(self) -> None:
         goods = [{"seq_num": 123}, {"exposure.seq_num": 234}, {"seq_num": 345, "otherkey": -1}]
         bads = [{"different_key": 123}]
         for good in goods:
@@ -204,7 +204,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         for bad in bads:
             self.assertFalse(_seqnum_present(bad))
 
-    def test__expid_present(self):
+    def test__expid_present(self) -> None:
         goods = [{"exposure": 123}, {"exposure.id": 234}, {"exposure.id": 345, "otherkey": -1}]
         bads = [{"different_key": 123}]
         for good in goods:
@@ -212,7 +212,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         for bad in bads:
             self.assertFalse(_expid_present(bad))
 
-    def test_getDayObs(self):
+    def test_getDayObs(self) -> None:
         dayVal = 98765
         goods = [{"day_obs": dayVal}, {"exposure.day_obs": dayVal}, {"day_obs": dayVal, "otherkey": -1}]
         bads = [{"different_key": 123}]
@@ -221,7 +221,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         for bad in bads:
             self.assertTrue(getDayObs(bad) is None)
 
-    def test_getSeqNum(self):
+    def test_getSeqNum(self) -> None:
         seqVal = 12345
         goods = [{"seq_num": seqVal}, {"exposure.seq_num": seqVal}, {"seq_num": seqVal, "otherkey": -1}]
         bads = [{"different_key": 123}]
@@ -230,7 +230,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         for bad in bads:
             self.assertTrue(getSeqNum(bad) is None)
 
-    def test_getExpId(self):
+    def test_getExpId(self) -> None:
         expIdVal = 12345
         goods = [{"exposure": expIdVal}, {"exposure.id": expIdVal}, {"exposure": expIdVal, "otherkey": -1}]
         bads = [{"different_key": 123}]
@@ -239,13 +239,13 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         for bad in bads:
             self.assertTrue(getExpId(bad) is None)
 
-    def test_datasetExists(self):
+    def test_datasetExists(self) -> None:
         self.assertTrue(self.butler.exists("raw", self.rawDataId))
         self.assertTrue(self.butler.exists("raw", self.expIdOnly))
         self.assertTrue(self.butler.exists("raw", self.dayObsSeqNumIdOnly))
         return
 
-    def test_sortRecordsByDayObsThenSeqNum(self):
+    def test_sortRecordsByDayObsThenSeqNum(self) -> None:
         where = "exposure.day_obs=dayObs"
         expRecords = self.butler.registry.queryDimensionRecords(
             "exposure", where=where, bind={"dayObs": RECENT_DAY}
@@ -268,18 +268,18 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
             sortedIds = sortRecordsByDayObsThenSeqNum(expRecords)
         return
 
-    def test_getDaysWithData(self):
+    def test_getDaysWithData(self) -> None:
         days = getDaysWithData(self.butler)
         self.assertTrue(len(days) >= 0)
         self.assertIsInstance(days[0], int)
         return
 
-    def test_getExpIdFromDayObsSeqNum(self):
+    def test_getExpIdFromDayObsSeqNum(self) -> None:
         expId = getExpIdFromDayObsSeqNum(self.butler, self.dayObsSeqNumIdOnly)
         self.assertTrue(_expid_present(expId))
         return
 
-    def test_updateDataIdOrDataCord(self):
+    def test_updateDataIdOrDataCord(self) -> None:
         updateVals = {"testKey": "testValue"}
 
         ids = [self.rawDataId, self.expRecordNoDetector, self.dataCoordMinimal]
@@ -289,7 +289,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
                 self.assertTrue(testId[k] == v)
         return
 
-    def test_fillDataId(self):
+    def test_fillDataId(self) -> None:
         self.assertFalse(_dayobs_present(self.expIdOnly))
         self.assertFalse(_seqnum_present(self.expIdOnly))
 
@@ -305,22 +305,22 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
             self.assertTrue(_expid_present(fullId))
         return
 
-    def test_getExpRecordFromDataId(self):
+    def test_getExpRecordFromDataId(self) -> None:
         record = getExpRecordFromDataId(self.butler, self.rawDataId)
         self.assertIsInstance(record, dafButler.DimensionRecord)
         return
 
-    def test_getDayObsSeqNumFromExposureId(self):
+    def test_getDayObsSeqNumFromExposureId(self) -> None:
         dayObsSeqNum = getDayObsSeqNumFromExposureId(self.butler, self.expIdOnly)
         self.assertTrue(_dayobs_present(dayObsSeqNum))
         self.assertTrue(_seqnum_present(dayObsSeqNum))
         return
 
-    def test_removeDataProduct(self):
+    def test_removeDataProduct(self) -> None:
         # Can't think of an easy or safe test for this
         return
 
-    def test_getLatissOnSkyDataIds(self):
+    def test_getLatissOnSkyDataIds(self) -> None:
         # This is very slow, consider removing as it's the least import of all
         # the util functions. However, restricting it to only the most recent
         # day does help a lot, so probably OK like that, and should speed up
@@ -345,7 +345,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         self.assertTrue(_expid_present(testId))
         return
 
-    def test__assureDict(self):
+    def test__assureDict(self) -> None:
         for item in [
             self.rawDataId,
             self.fullId,
@@ -358,7 +358,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
             self.assertIsInstance(testId, dict)
         return
 
-    def test__get_dayobs_key(self):
+    def test__get_dayobs_key(self) -> None:
         dataId = {"a_random_key": 321, "exposure.day_obs": 20200312, "z_random_key": "abc"}
         self.assertTrue(_get_dayobs_key(dataId) == "exposure.day_obs")
         dataId = {"day_obs": 20200312}
@@ -367,7 +367,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         self.assertTrue(_get_dayobs_key(dataId) is None)
         return
 
-    def test__get_seqnum_key(self):
+    def test__get_seqnum_key(self) -> None:
         dataId = {"a_random_key": 321, "exposure.seq_num": 123, "z_random_key": "abc"}
         self.assertTrue(_get_seqnum_key(dataId) == "exposure.seq_num")
         dataId = {"seq_num": 123}
@@ -376,7 +376,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         self.assertTrue(_get_seqnum_key(dataId) is None)
         return
 
-    def test__get_expid_key(self):
+    def test__get_expid_key(self) -> None:
         dataId = {"a_random_key": 321, "exposure.id": 123, "z_random_key": "abc"}
         self.assertTrue(_get_expid_key(dataId) == "exposure.id")
         dataId = {"a_random_key": 321, "exposure": 123, "z_random_key": "abc"}
@@ -385,7 +385,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         self.assertTrue(_get_expid_key(dataId) is None)
         return
 
-    def test_updateDataId(self):
+    def test_updateDataId(self) -> None:
         # check with a dataCoordinate
         dataId = copy.copy(self.expRecordNoDetector.dataId)
         self.assertTrue("detector" not in dataId)
@@ -402,7 +402,7 @@ class ButlerUtilsTestCase(lsst.utils.tests.TestCase):
         self.assertTrue("detector" in dataId)
         self.assertEqual(dataId["detector"], 321)
 
-    def test_getExpRecord(self):
+    def test_getExpRecord(self) -> None:
         expId = self.expIdOnly["exposure"]
         dayObs = self.dayObsSeqNumIdOnly["day_obs"]
         seqNum = self.dayObsSeqNumIdOnly["seq_num"]
@@ -431,7 +431,7 @@ class ButlerInitTestCase(lsst.utils.tests.TestCase):
     not possible.
     """
 
-    def test_dafButlerRaiseTypes(self):
+    def test_dafButlerRaiseTypes(self) -> None:
         # If DAF_BUTLER_REPOSITORY_INDEX is not set *at all* then
         # using an instrument label raises a FileNotFoundError
         with unittest.mock.patch.dict("os.environ"):
@@ -453,7 +453,7 @@ class ButlerInitTestCase(lsst.utils.tests.TestCase):
             with self.assertRaises(FileNotFoundError):
                 dafButler.Butler("NotAValidCameraName")
 
-    def test_makeDefaultLatissButlerRaiseTypes(self):
+    def test_makeDefaultLatissButlerRaiseTypes(self) -> None:
         """makeDefaultLatissButler unifies the mixed exception types from
         butler inits, so test all available possibilities here.
         """
@@ -474,7 +474,7 @@ class ButlerInitTestCase(lsst.utils.tests.TestCase):
             with self.assertRaises(FileNotFoundError):
                 makeDefaultLatissButler()
 
-    def test_DAF_BUTLER_REPOSITORY_INDEX_value(self):
+    def test_DAF_BUTLER_REPOSITORY_INDEX_value(self) -> None:
         # If DAF_BUTLER_REPOSITORY_INDEX is truthy then we expect it to point
         # to an actual file
         repoFile = os.getenv("DAF_BUTLER_REPOSITORY_INDEX")
@@ -486,7 +486,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_consdbClient.py
+++ b/tests/test_consdbClient.py
@@ -272,9 +272,9 @@ def test_insert_allow_update(client: ConsDbClient) -> None:
 def test_insert_bad_obs_id_tuple(client: ConsDbClient) -> None:
     """A tuple that is not length 2 or 3 is rejected before any request."""
     with pytest.raises(AssertionError, match="obs_id tuple"):
-        client.insert("latiss", "exposure", (20240603,), {"foo": 1})
+        client.insert("latiss", "exposure", (20240603,), {"foo": 1})  # type: ignore[arg-type]
     with pytest.raises(AssertionError, match="obs_id tuple"):
-        client.insert("latiss", "exposure", (20240603, 123, 94, 0), {"foo": 1})
+        client.insert("latiss", "exposure", (20240603, 123, 94, 0), {"foo": 1})  # type: ignore[arg-type]
 
 
 def test_insert_no_values(client: ConsDbClient) -> None:
@@ -316,7 +316,9 @@ def test_getCcdVisitTableForDay_dedupes_overlapping_columns(client: ConsDbClient
 
     # Only inspect the SELECT clause; the WHERE clause legitimately references
     # cv.visit_id etc. in its join conditions.
-    sentQuery = json.loads(responses.calls[1].request.body)["query"]
+    requestBody = responses.calls[1].request.body
+    assert requestBody is not None
+    sentQuery = json.loads(requestBody)["query"]
     selectClause = sentQuery.split(" FROM ")[0]
     # Columns already provided by cvq.* must not be re-selected explicitly...
     assert "cvq.*" in selectClause
@@ -337,7 +339,9 @@ def test_getCcdVisitTableForDay_keeps_columns_when_no_overlap(client: ConsDbClie
 
     getCcdVisitTableForDay(client, 20240101)
 
-    sentQuery = json.loads(responses.calls[1].request.body)["query"]
+    requestBody = responses.calls[1].request.body
+    assert requestBody is not None
+    sentQuery = json.loads(requestBody)["query"]
     selectClause = sentQuery.split(" FROM ")[0]
     for col in ("cv.detector", "cv.visit_id", "v.band", "v.exp_time", "v.seq_num", "v.day_obs", "v.img_type"):
         assert col in selectClause

--- a/tests/test_consdbClient.py
+++ b/tests/test_consdbClient.py
@@ -31,14 +31,14 @@ from lsst.summit.utils.consdbClient import getCcdVisitTableForDay
 
 
 @pytest.fixture
-def client():
+def client() -> ConsDbClient:
     """Initialize client with a fake url
     Requires mocking connection with @responses.activate decorator
     """
     return ConsDbClient("http://example.com/consdb")
 
 
-def test_table_name():
+def test_table_name() -> None:
     instrument = "latiss"
     obs_type = "exposure"
     assert (
@@ -48,7 +48,7 @@ def test_table_name():
 
 
 @responses.activate
-def test_add_flexible_metadata_key(client):
+def test_add_flexible_metadata_key(client: ConsDbClient) -> None:
     instrument = "latiss"
     obs_type = "exposure"
     responses.post(
@@ -106,7 +106,7 @@ def test_add_flexible_metadata_key(client):
 
 
 @responses.activate
-def test_get_flexible_metadata_keys(client):
+def test_get_flexible_metadata_keys(client: ConsDbClient) -> None:
     description = {"foo": ["bool", "a", None, None], "bar": ["float", "b", "deg", "pos.eq.ra"]}
     responses.get(
         "http://example.com/consdb/flex/latiss/exposure/schema",
@@ -121,7 +121,7 @@ def test_get_flexible_metadata_keys(client):
 
 
 @responses.activate
-def test_get_flexible_metadata(client):
+def test_get_flexible_metadata(client: ConsDbClient) -> None:
     results = {"bool_key": True, "int_key": 42, "float_key": 3.14159, "str_key": "foo"}
     responses.get(
         "http://example.com/consdb/flex/latiss/exposure/obs/271828",
@@ -148,7 +148,7 @@ def test_get_flexible_metadata(client):
 
 
 @responses.activate
-def test_insert_flexible_metadata(client):
+def test_insert_flexible_metadata(client: ConsDbClient) -> None:
     instrument = "latiss"
     obs_type = "exposure"
     with pytest.raises(ValueError):
@@ -157,7 +157,7 @@ def test_insert_flexible_metadata(client):
 
 
 @responses.activate
-def test_schema(client):
+def test_schema(client: ConsDbClient) -> None:
     description = {"foo": ("bool", "a"), "bar": ("int", "b")}
     responses.get(
         "http://example.com/consdb/schema/latiss/misc_table",
@@ -178,7 +178,7 @@ def test_schema(client):
         (":alberta94", "***:al***"),
     ],
 )
-def test_clean_token_url_response(secret, redacted):
+def test_clean_token_url_response(secret: str, redacted: str) -> None:
     """Test tokens URL is cleaned when an error is thrown from requests
     Use with pytest raises assert an error'
     assert that url does not contain tokens
@@ -201,13 +201,13 @@ def test_clean_token_url_response(secret, redacted):
     assert url == sanitized
 
 
-def test_client(client):
+def test_client(client: ConsDbClient) -> None:
     """Test ConsDbClient is initialized properly"""
     assert "clean_url" in str(client.session.hooks["response"])
 
 
 @responses.activate
-def test_insert_obs_id(client):
+def test_insert_obs_id(client: ConsDbClient) -> None:
     """An integer obs_id targets the ``.../obs/{obs_id}`` endpoint."""
     responses.post(
         "http://example.com/consdb/insert/latiss/exposure/obs/271828",
@@ -222,7 +222,7 @@ def test_insert_obs_id(client):
 
 
 @responses.activate
-def test_insert_by_seq_num(client):
+def test_insert_by_seq_num(client: ConsDbClient) -> None:
     """A 2-tuple targets the ``.../{day_obs}/{seq_num}`` endpoint."""
     responses.post(
         "http://example.com/consdb/insert/latiss/exposure/by_seq_num/20240603/123",
@@ -237,7 +237,7 @@ def test_insert_by_seq_num(client):
 
 
 @responses.activate
-def test_insert_by_seq_num_detector(client):
+def test_insert_by_seq_num_detector(client: ConsDbClient) -> None:
     """A 3-tuple targets the ``.../{day_obs}/{seq_num}/{detector}``
     endpoint for per-detector (ccdexposure-level) tables."""
     responses.post(
@@ -254,7 +254,7 @@ def test_insert_by_seq_num_detector(client):
 
 
 @responses.activate
-def test_insert_allow_update(client):
+def test_insert_allow_update(client: ConsDbClient) -> None:
     """allow_update appends ``?u=1`` to upsert against the addressed key."""
     responses.post(
         "http://example.com/consdb/insert/lsstcam/ccdexposure/by_seq_num/20240603/123/94?u=1",
@@ -269,7 +269,7 @@ def test_insert_allow_update(client):
     )
 
 
-def test_insert_bad_obs_id_tuple(client):
+def test_insert_bad_obs_id_tuple(client: ConsDbClient) -> None:
     """A tuple that is not length 2 or 3 is rejected before any request."""
     with pytest.raises(AssertionError, match="obs_id tuple"):
         client.insert("latiss", "exposure", (20240603,), {"foo": 1})
@@ -277,14 +277,14 @@ def test_insert_bad_obs_id_tuple(client):
         client.insert("latiss", "exposure", (20240603, 123, 94, 0), {"foo": 1})
 
 
-def test_insert_no_values(client):
+def test_insert_no_values(client: ConsDbClient) -> None:
     """Inserting with no values raises before any request."""
     with pytest.raises(ValueError, match="No values to insert"):
         client.insert("latiss", "exposure", 271828, {})
 
 
 @responses.activate
-def test_getCcdVisitTableForDay_dedupes_overlapping_columns(client):
+def test_getCcdVisitTableForDay_dedupes_overlapping_columns(client: ConsDbClient) -> None:
     """Columns already present in ccdvisit1_quicklook must not be re-selected.
 
     ``cvq.*`` pulls in every column of ccdvisit1_quicklook. As ConsDB
@@ -329,7 +329,7 @@ def test_getCcdVisitTableForDay_dedupes_overlapping_columns(client):
 
 
 @responses.activate
-def test_getCcdVisitTableForDay_keeps_columns_when_no_overlap(client):
+def test_getCcdVisitTableForDay_keeps_columns_when_no_overlap(client: ConsDbClient) -> None:
     """When the quicklook table shares no names, every extra is selected."""
     url = "http://example.com/consdb/query"
     responses.post(url, json={"columns": ["ccdvisit_id", "psf_sigma"], "data": []})

--- a/tests/test_dateTime.py
+++ b/tests/test_dateTime.py
@@ -38,7 +38,7 @@ from lsst.summit.utils.dateTime import (  # TODO: add tests for efdTimestampToAs
 
 class DateTimeTestCase(lsst.utils.tests.TestCase):
 
-    def test_getDayObsAsTimes(self):
+    def test_getDayObsAsTimes(self) -> None:
         """This tests getDayObsStartTime and getDayObsEndTime explicitly,
         but the days we loop over are chosen to test calcNextDay() which is
         called by getDayObsEndTime().
@@ -61,7 +61,7 @@ class DateTimeTestCase(lsst.utils.tests.TestCase):
             self.assertGreater(dayEnd, dayStart)
             self.assertEqual(dayEnd.jd, dayStart.jd + 1)
 
-    def test_calcDayOffset(self):
+    def test_calcDayOffset(self) -> None:
         self.assertEqual(calcDayOffset(20230531, 20230601), 1)
         self.assertEqual(calcDayOffset(20230531, 20230530), -1)
         self.assertEqual(calcDayOffset(20230531, 20230531), 0)
@@ -72,7 +72,7 @@ class DateTimeTestCase(lsst.utils.tests.TestCase):
 
         self.assertNotEqual(calcDayOffset(20230531, 20230601), -1)
 
-    def test_getDayObsForTime(self):
+    def test_getDayObsForTime(self) -> None:
         pydate = datetime.datetime(2023, 2, 5, 13, 30, 1)
         time = Time(pydate)
         dayObs = getDayObsForTime(time)
@@ -89,7 +89,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_efdUtils.py
+++ b/tests/test_efdUtils.py
@@ -24,6 +24,7 @@
 import asyncio
 import datetime
 import unittest
+from typing import Any
 
 import astropy
 import pandas as pd
@@ -58,9 +59,16 @@ vcr = getVcr()
 @unittest.skipIf(not HAS_EFD_CLIENT, "No EFD client available")
 @vcr.use_cassette()
 class EfdUtilsTestCase(lsst.utils.tests.TestCase):
+    # class attributes populated in setUpClass
+    client: Any
+    dayObs: int
+    axisTopic: str
+    timeSeriesTopic: str
+    event: TMAEvent
+
     @classmethod
     @vcr.use_cassette()
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         try:
             cls.client = makeEfdClient(testing=True)
         except RuntimeError:
@@ -84,17 +92,17 @@ class EfdUtilsTestCase(lsst.utils.tests.TestCase):
         )
 
     @vcr.use_cassette()
-    def tearDown(self):
+    def tearDown(self) -> None:
         loop = asyncio.get_event_loop()
         if self.client.influx_client is not None:
             loop.run_until_complete(self.client.influx_client.close())
 
     @vcr.use_cassette()
-    def test_makeEfdClient(self):
+    def test_makeEfdClient(self) -> None:
         self.assertIsInstance(self.client, lsst_efd_client.efd_helper.EfdClient)
 
     @vcr.use_cassette()
-    def test_getTopics(self):
+    def test_getTopics(self) -> None:
         topics = getTopics(self.client, "lsst.sal.MTMount*")
         self.assertIsInstance(topics, list)
         self.assertGreater(len(topics), 0)
@@ -114,7 +122,7 @@ class EfdUtilsTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(len(topics), 0)
 
     @vcr.use_cassette()
-    def test_getEfdData(self):
+    def test_getEfdData(self) -> None:
         dayStart = getDayObsStartTime(self.dayObs)
         dayEnd = getDayObsEndTime(self.dayObs)
         oneDay = datetime.timedelta(hours=24)
@@ -173,7 +181,7 @@ class EfdUtilsTestCase(lsst.utils.tests.TestCase):
             _ = getEfdData(self.client, "badTopic", begin=dayStart, end=dayEnd)
 
     @vcr.use_cassette()
-    def test_raiseIfTopicNotInSchema(self):
+    def test_raiseIfTopicNotInSchema(self) -> None:
         dayStart = getDayObsStartTime(self.dayObs)
         dayEnd = getDayObsEndTime(self.dayObs)
 
@@ -186,7 +194,7 @@ class EfdUtilsTestCase(lsst.utils.tests.TestCase):
             _ = getEfdData(self.client, badTopic, begin=dayStart, end=dayEnd)
 
     @vcr.use_cassette()
-    def test_getMostRecentRowWithDataBefore(self):
+    def test_getMostRecentRowWithDataBefore(self) -> None:
         time = Time(1687845854.736784, scale="utc", format="unix")
         rowData = getMostRecentRowWithDataBefore(
             self.client, "lsst.sal.MTM1M3.logevent_forceActuatorState", time
@@ -196,19 +204,19 @@ class EfdUtilsTestCase(lsst.utils.tests.TestCase):
         stateTime = efdTimestampToAstropy(rowData["private_efdStamp"])
         self.assertLess(stateTime, time)
 
-    def test_efdTimestampToAstropy(self):
+    def test_efdTimestampToAstropy(self) -> None:
         time = efdTimestampToAstropy(1687845854.736784)
         self.assertIsInstance(time, astropy.time.Time)
         return
 
-    def test_astropyToEfdTimestamp(self):
+    def test_astropyToEfdTimestamp(self) -> None:
         time = Time(1687845854.736784, scale="utc", format="unix")
         efdTimestamp = astropyToEfdTimestamp(time)
         self.assertIsInstance(efdTimestamp, float)
         return
 
     @vcr.use_cassette()
-    def test_clipDataToEvent(self):
+    def test_clipDataToEvent(self) -> None:
         # get 10 mins of data either side of the event we'll clip to
         duration = datetime.timedelta(seconds=10 * 60)
         queryBegin = self.event.begin - duration
@@ -261,7 +269,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_guider.py
+++ b/tests/test_guider.py
@@ -290,7 +290,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_ics.py
+++ b/tests/test_ics.py
@@ -24,6 +24,7 @@ import logging
 import os
 import tempfile
 import unittest
+from typing import Any
 
 import matplotlib.pyplot as plt
 from utils import getVcr
@@ -32,16 +33,26 @@ import lsst.utils.tests
 from lsst.summit.utils.efdUtils import makeEfdClient
 from lsst.summit.utils.m1m3.inertia_compensation_system import evaluate_m1m3_ics_single_slew
 from lsst.summit.utils.m1m3.plots.plot_ics import FIGURE_HEIGHT, FIGURE_WIDTH, plot_hp_measured_data
-from lsst.summit.utils.tmaUtils import TMAEventMaker
+from lsst.summit.utils.tmaUtils import TMAEvent, TMAEventMaker
 
 vcr = getVcr()
 
 
 @vcr.use_cassette()
 class M1M3ICSTestCase(lsst.utils.tests.TestCase):
+    # class attributes populated in setUp
+    client: Any
+    dayObs: int
+    seqNumToPlot: int
+    tmaEventMaker: TMAEventMaker
+    events: list[TMAEvent]
+    sampleData: Any
+    outputDir: str
+    log: logging.Logger
+
     @classmethod
     @vcr.use_cassette()
-    def setUp(cls):
+    def setUp(cls) -> None:
         try:
             cls.client = makeEfdClient(testing=True)
         except RuntimeError:
@@ -57,13 +68,13 @@ class M1M3ICSTestCase(lsst.utils.tests.TestCase):
         cls.log = logging.getLogger(__name__)
 
     @vcr.use_cassette()
-    def tearDown(self):
+    def tearDown(self) -> None:
         loop = asyncio.get_event_loop()
         if self.client.influx_client is not None:
             loop.run_until_complete(self.client.influx_client.close())
 
     @vcr.use_cassette()
-    def test_analysis(self):
+    def test_analysis(self) -> None:
         self.log.info(f"Writing temp output files to {self.outputDir}")
         plotFilename = os.path.join(self.outputDir, "testPlotting_exp.jpg")
         statFilename = os.path.join(self.outputDir, "m1m3_ics_stats.csv")
@@ -94,7 +105,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_imageExaminer.py
+++ b/tests/test_imageExaminer.py
@@ -24,6 +24,7 @@ import tempfile
 import unittest
 
 import lsst.utils.tests
+from lsst.daf.butler import Butler
 from lsst.summit.utils import ImageExaminer
 from lsst.summit.utils.bestEffort import BestEffortIsr
 from lsst.summit.utils.butlerUtils import makeDefaultLatissButler
@@ -31,8 +32,15 @@ from lsst.summit.utils.utils import getSite
 
 
 class ImageExaminerTestCase(lsst.utils.tests.TestCase):
+    # class attributes populated in setUpClass
+    butler: Butler
+    dataId: dict[str, int]
+    bestEffort: BestEffortIsr
+    outputDir: str
+    outputFilename: str
+
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         try:
             if getSite() == "jenkins":
                 raise unittest.SkipTest("Skip running butler-driven tests in Jenkins.")
@@ -46,7 +54,7 @@ class ImageExaminerTestCase(lsst.utils.tests.TestCase):
         cls.outputDir = tempfile.mkdtemp()
         cls.outputFilename = os.path.join(cls.outputDir, "testImageExaminer.jpg")
 
-    def test_imageExaminer(self):
+    def test_imageExaminer(self) -> None:
         """Test that the animator produces a large file without worrying about
         the contents?
         """
@@ -64,7 +72,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_nightReport.py
+++ b/tests/test_nightReport.py
@@ -35,13 +35,21 @@ import lsst.utils.tests
 mpl.use("Agg")
 
 import lsst.summit.utils.butlerUtils as butlerUtils  # noqa: E402
+from lsst.daf.butler import Butler  # noqa: E402
 from lsst.summit.utils.nightReport import ColorAndMarker, NightReport  # noqa: E402
 from lsst.summit.utils.utils import getSite  # noqa: E402
 
 
 class NightReportTestCase(lsst.utils.tests.TestCase):
+    # class attributes populated in setUpClass
+    butler: Butler
+    dayObs: int
+    report: NightReport
+    nImages: int
+    seqNums: list[int]
+
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         try:
             if getSite() == "jenkins":
                 raise unittest.SkipTest("Skip running butler-driven tests in Jenkins.")
@@ -61,7 +69,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         cls.nImages = len(cls.report.data.keys())
         cls.seqNums = list(cls.report.data.keys())
 
-    def test_saveAndLoad(self):
+    def test_saveAndLoad(self) -> None:
         """Test that a NightReport can save itself, and be loaded back."""
         writeDir = tempfile.mkdtemp()
         saveFile = os.path.join(writeDir, f"testNightReport_{self.dayObs}.pickle")
@@ -75,7 +83,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
 
         # TODO: add a self.assertRaises on a mismatched dayObs
 
-    def test_getSortedData(self):
+    def test_getSortedData(self) -> None:
         """Test the _getSortedData returns the seqNums in order."""
         shuffledKeys = list(self.report.data.keys())
         shuffle(shuffledKeys)
@@ -86,7 +94,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(sortedKeys, list(self.report.data.keys()))
         return
 
-    def test_getExpRecordDictForDayObs(self):
+    def test_getExpRecordDictForDayObs(self) -> None:
         """Test getExpRecordDictForDayObs.
 
         Test it returns a dict of dicts, keyed by integer seqNums.
@@ -103,7 +111,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         self.assertTrue(all(isinstance(expRecDict[s], dict) for s in seqNums))
         return
 
-    def test_getObsInfoAndMetadataForSeqNum(self):
+    def test_getObsInfoAndMetadataForSeqNum(self) -> None:
         """Test that getObsInfoAndMetadataForSeqNum returns the correct
         types.
         """
@@ -113,7 +121,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         self.assertIsInstance(md, dict)
         return
 
-    def test_rebuild(self):
+    def test_rebuild(self) -> None:
         """Test that rebuild does nothing, as no data will be being added.
 
         NB Do not call full=True on this, as it will double the length of the
@@ -124,7 +132,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(len(self.report.data), lenBefore)
         return
 
-    def test_getExposureMidpoint(self):
+    def test_getExposureMidpoint(self) -> None:
         """Test the exposure midpoint calculation"""
         # we would like a non-zero exptime exposure really
         seqNumToUse = 0
@@ -145,13 +153,13 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
             self.assertLess(midPoint, record["datetime_end"].to_datetime())
         return
 
-    def test_getTimeDeltas(self):
+    def test_getTimeDeltas(self) -> None:
         """Test the time delta calculation returns a dict."""
         dts = self.report.getTimeDeltas()
         self.assertIsInstance(dts, dict)
         return
 
-    def test_makeStarColorAndMarkerMap(self):
+    def test_makeStarColorAndMarkerMap(self) -> None:
         """Test the color map maker returns a dict of ColorAndMarker
         objects.
         """
@@ -162,7 +170,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         self.assertTrue(all(isinstance(value, ColorAndMarker) for value in values))
         return
 
-    def test_printObsTable(self):
+    def test_printObsTable(self) -> None:
         """Test that a the printObsTable() method prints out the correct
         number of lines.
         """
@@ -172,7 +180,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         # newline for each row plus header line, plus the line with dashes
         self.assertEqual(len(fake_stdout.mock_calls), 2 * (self.nImages + 2))
 
-    def test_plotPerObjectAirMass(self):
+    def test_plotPerObjectAirMass(self) -> None:
         """Test that a the per-object airmass plots runs."""
         # We assume matplotlib is making plots, so just check that these
         # don't crash.
@@ -188,7 +196,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         # flip and select stars
         self.report.plotPerObjectAirMass(objects=self.report.stars[0], airmassOneAtTop=True)  # both
 
-    def test_makeAltAzCoveragePlot(self):
+    def test_makeAltAzCoveragePlot(self) -> None:
         """Test that a the polar coverage plotting code runs."""
         # We assume matplotlib is making plots, so just check that these
         # don't crash.
@@ -202,7 +210,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         # test turning lines off
         self.report.makeAltAzCoveragePlot(objects=self.report.stars[0:2], withLines=False)
 
-    def test_calcShutterTimes(self):
+    def test_calcShutterTimes(self) -> None:
         timings = self.report.calcShutterTimes()
         if not timings:
             return  # if the day has no on-sky observations, this returns None
@@ -210,13 +218,13 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         self.assertGreater(efficiency, 0)
         self.assertLessEqual(efficiency, 100)
 
-    def test_getDatesForSeqNums(self):
+    def test_getDatesForSeqNums(self) -> None:
         dateTimeDict = self.report.getDatesForSeqNums()
         self.assertIsInstance(dateTimeDict, dict)
         self.assertTrue(all(isinstance(seqNum, int) for seqNum in dateTimeDict.keys()))
         self.assertTrue(all(isinstance(seqNum, datetime.datetime) for seqNum in dateTimeDict.values()))
 
-    def test_doesNotRaise(self):
+    def test_doesNotRaise(self) -> None:
         """Tests for things which are hard to test, so just make sure they
         run.
         """
@@ -227,7 +235,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         for threshold, includeCalibs in itertools.product((0, 1, 10), (True, False)):
             self.report.printObsGaps(threshold=threshold, includeCalibs=includeCalibs)
 
-    def test_internals(self):
+    def test_internals(self) -> None:
         startNum = self.report.getObservingStartSeqNum()
         self.assertIsInstance(startNum, int)
         self.assertGreater(startNum, 0)  # the day starts at 1, so zero would be an error of some sort
@@ -247,7 +255,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_nightReport.py
+++ b/tests/test_nightReport.py
@@ -136,6 +136,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
         """Test the exposure midpoint calculation"""
         # we would like a non-zero exptime exposure really
         seqNumToUse = 0
+        expTime = 0
         for seqNum in self.report.data.keys():
             expTime = self.report.data[seqNum]["exposure_time"]
             if expTime > 0:
@@ -238,6 +239,7 @@ class NightReportTestCase(lsst.utils.tests.TestCase):
     def test_internals(self) -> None:
         startNum = self.report.getObservingStartSeqNum()
         self.assertIsInstance(startNum, int)
+        assert startNum is not None
         self.assertGreater(startNum, 0)  # the day starts at 1, so zero would be an error of some sort
 
         starsFromGetter = self.report.getObservedObjects()

--- a/tests/test_packageVersions.py
+++ b/tests/test_packageVersions.py
@@ -1,0 +1,395 @@
+# This file is part of summit_utils.
+#
+# Developed for the LSST Data Management System.
+# This product includes software developed by the LSST Project
+# (https://www.lsst.org).
+# See the COPYRIGHT file at the top-level directory of this distribution
+# for details of code ownership.
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+"""Tests for the science-package version data model and its ConsDB round-trip.
+
+Two wire formats are pinned here and must not drift without a migration plan:
+the ConsDB JSON blob (``{"versions": {...}, "version_number": N}``) and the
+on-disk version-number registry written by the Rapid Analysis head node
+(``{"entries": [{"number", "hash", "versions", "firstSeen"}]}``) - deployed
+registry files and any already-written ConsDB rows use these shapes, so the
+verbatim-decode tests below fail if either changes.
+"""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+import responses
+
+from lsst.summit.utils import ConsDbClient
+from lsst.summit.utils.packageVersions import (
+    PACKAGE_VERSIONS_COLUMN,
+    UNKNOWN_VERSION_NUMBER,
+    PackageVersions,
+    getRegistryPath,
+    loadPackageVersionRegistry,
+    readPackageVersionsFromConsDb,
+    resolveVersionNumber,
+    writeBackdatedPackageVersions,
+    writePackageVersionsToConsDb,
+)
+from lsst.summit.utils.utils import computeExposureId
+
+VERSIONS = {"ts_wep": "v17.6.1-alpha", "donut_viz": "v4.4.0-alpha", "rubintv_production": "abc123"}
+
+
+@pytest.fixture
+def client() -> ConsDbClient:
+    """A ConsDbClient pointed at a fake url; use @responses.activate to mock
+    the connection.
+    """
+    return ConsDbClient("http://example.com/consdb")
+
+
+def test_toDictPinsBlobShape() -> None:
+    # this is the wire format written to the ConsDB JSONB column - an exact
+    # match, not a subset check, so any shape drift fails here
+    pv = PackageVersions(versions=dict(VERSIONS), versionNumber=42)
+    assert pv.toDict() == {"versions": VERSIONS, "version_number": 42}
+    # version_number is always present, null when unknown
+    assert PackageVersions(versions=dict(VERSIONS)).toDict() == {"versions": VERSIONS, "version_number": None}
+
+
+def test_dictRoundTrip() -> None:
+    pv = PackageVersions(versions=dict(VERSIONS), versionNumber=42)
+    assert PackageVersions.fromDict(pv.toDict()) == pv
+    pvNoNumber = PackageVersions(versions=dict(VERSIONS))
+    assert PackageVersions.fromDict(pvNoNumber.toDict()) == pvNoNumber
+
+
+def test_jsonRoundTrip() -> None:
+    pv = PackageVersions(versions=dict(VERSIONS), versionNumber=42)
+    assert PackageVersions.fromJson(pv.toJson()) == pv
+    # canonical: sorted keys, so identical sets serialise identically
+    reordered = PackageVersions(versions=dict(reversed(list(VERSIONS.items()))), versionNumber=42)
+    assert reordered.toJson() == pv.toJson()
+
+
+def test_fromDictToleratesMissingVersionNumber() -> None:
+    # a blob without the version_number key parses as unknown, not an error
+    pv = PackageVersions.fromDict({"versions": VERSIONS})
+    assert pv.versions == VERSIONS
+    assert pv.versionNumber is None
+
+
+def test_fromDictRejectsMissingVersions() -> None:
+    with pytest.raises(ValueError, match="no 'versions' key"):
+        PackageVersions.fromDict({"version_number": 42})
+
+
+def test_fromJsonRejectsNonObject() -> None:
+    with pytest.raises(ValueError, match="Expected a JSON object"):
+        PackageVersions.fromJson('["not", "an", "object"]')
+
+
+def test_versionHashStableAndOrderIndependent() -> None:
+    a = PackageVersions(versions={"ts_wep": "v1", "donut_viz": "v2"})
+    b = PackageVersions(versions={"donut_viz": "v2", "ts_wep": "v1"})  # different insertion order
+    assert a.versionHash() == b.versionHash()
+
+
+def test_versionHashIgnoresVersionNumber() -> None:
+    # the number is derived from the hash, so it must not feed back into it
+    a = PackageVersions(versions={"ts_wep": "v1"}, versionNumber=1)
+    b = PackageVersions(versions={"ts_wep": "v1"}, versionNumber=99)
+    assert a.versionHash() == b.versionHash()
+
+
+def test_versionHashChangesWhenAVersionChanges() -> None:
+    a = PackageVersions(versions={"ts_wep": "v1", "donut_viz": "v2"})
+    c = PackageVersions(versions={"ts_wep": "v1", "donut_viz": "v3"})
+    assert a.versionHash() != c.versionHash()
+
+
+def test_getRegistryPathIsPerInstrument() -> None:
+    path = getRegistryPath("/some/dir", "LSSTCam")
+    assert path == "/some/dir/packageVersionRegistry-LSSTCam.json"
+    assert path != getRegistryPath("/some/dir", "LSSTComCam")
+
+
+def test_resolveVersionNumberFirstSetGetsOne(tmp_path: Path) -> None:
+    path = getRegistryPath(str(tmp_path), "LSSTCam")
+    pv = PackageVersions(versions={"ts_wep": "v1"})
+    assert resolveVersionNumber(path, pv, timestamp="t0") == 1
+
+
+def test_resolveVersionNumberSameSetReturnsSameNumber(tmp_path: Path) -> None:
+    path = getRegistryPath(str(tmp_path), "LSSTCam")
+    pv = PackageVersions(versions={"ts_wep": "v1"})
+    first = resolveVersionNumber(path, pv, timestamp="t0")
+    second = resolveVersionNumber(path, pv, timestamp="t1")  # later call, same versions
+    assert first == second
+
+
+def test_resolveVersionNumberNewSetIncrements(tmp_path: Path) -> None:
+    path = getRegistryPath(str(tmp_path), "LSSTCam")
+    pv1 = PackageVersions(versions={"ts_wep": "v1"})
+    pv2 = PackageVersions(versions={"ts_wep": "v2"})
+    assert resolveVersionNumber(path, pv1, timestamp="t0") == 1
+    assert resolveVersionNumber(path, pv2, timestamp="t1") == 2
+    # and the old set still maps to its original number
+    assert resolveVersionNumber(path, pv1, timestamp="t2") == 1
+
+
+def test_resolveVersionNumberPersistsRegistryFormat(tmp_path: Path) -> None:
+    # pins the on-disk registry file format written by the head node
+    path = getRegistryPath(str(tmp_path), "LSSTCam")
+    pv1 = PackageVersions(versions={"ts_wep": "v1"})
+    pv2 = PackageVersions(versions={"ts_wep": "v2"})
+    resolveVersionNumber(path, pv1, timestamp="t0")
+    resolveVersionNumber(path, pv2, timestamp="t1")
+    with open(path) as f:
+        entries = json.load(f)["entries"]
+    assert len(entries) == 2
+    byNumber = {e["number"]: e for e in entries}
+    assert byNumber[1]["versions"] == {"ts_wep": "v1"}
+    assert byNumber[2]["versions"] == {"ts_wep": "v2"}
+    assert byNumber[1]["hash"] == pv1.versionHash()
+    assert byNumber[1]["firstSeen"] == "t0"
+
+
+def test_resolveVersionNumberCreatesMissingDirectory(tmp_path: Path) -> None:
+    path = getRegistryPath(str(tmp_path / "newdir"), "LSSTCam")
+    pv = PackageVersions(versions={"ts_wep": "v1"})
+    assert resolveVersionNumber(path, pv, timestamp="t0") == 1
+    assert os.path.isfile(path)
+
+
+def test_resolveVersionNumberRobustToUnwritablePath(tmp_path: Path) -> None:
+    # a path under a regular file (not a dir) can't be created -> sentinel
+    notADir = tmp_path / "afile"
+    notADir.write_text("x")
+    path = os.path.join(str(notADir), "packageVersionRegistry-LSSTCam.json")
+    pv = PackageVersions(versions={"ts_wep": "v1"})
+    assert resolveVersionNumber(path, pv, timestamp="t0") == UNKNOWN_VERSION_NUMBER
+
+
+def test_resolveVersionNumberRobustToMalformedRegistry(tmp_path: Path) -> None:
+    path = getRegistryPath(str(tmp_path), "LSSTCam")
+    with open(path, "w") as f:
+        f.write("{ this is not valid json")
+    pv = PackageVersions(versions={"ts_wep": "v1"})
+    assert resolveVersionNumber(path, pv, timestamp="t0") == UNKNOWN_VERSION_NUMBER
+
+
+def test_loadPackageVersionRegistryRoundTrip(tmp_path: Path) -> None:
+    path = getRegistryPath(str(tmp_path), "LSSTCam")
+    pv1 = PackageVersions(versions={"ts_wep": "v1"})
+    pv2 = PackageVersions(versions={"ts_wep": "v2"})
+    resolveVersionNumber(path, pv1, timestamp="t0")
+    resolveVersionNumber(path, pv2, timestamp="t1")
+    registry = loadPackageVersionRegistry(path)
+    assert registry == {
+        1: PackageVersions(versions={"ts_wep": "v1"}, versionNumber=1),
+        2: PackageVersions(versions={"ts_wep": "v2"}, versionNumber=2),
+    }
+
+
+def test_loadPackageVersionRegistryDecodesDeployedFormat(tmp_path: Path) -> None:
+    # a verbatim registry file as written by the deployed head node; if this
+    # fails, reading back-dated data from the summit has been broken
+    deployedRegistry = {
+        "entries": [
+            {
+                "firstSeen": "2026-07-20T01:02:03.456789+00:00",
+                "hash": "0f" * 32,
+                "number": 1,
+                "versions": {"ts_wep": "v17.6.1-alpha", "danish": "1.1.1"},
+            }
+        ]
+    }
+    path = tmp_path / "packageVersionRegistry-LSSTCam.json"
+    path.write_text(json.dumps(deployedRegistry))
+    registry = loadPackageVersionRegistry(str(path))
+    assert registry == {
+        1: PackageVersions(versions={"ts_wep": "v17.6.1-alpha", "danish": "1.1.1"}, versionNumber=1)
+    }
+
+
+def test_loadPackageVersionRegistryRaisesOnMissingFile(tmp_path: Path) -> None:
+    with pytest.raises(FileNotFoundError):
+        loadPackageVersionRegistry(str(tmp_path / "nonexistent.json"))
+
+
+def test_loadPackageVersionRegistryRaisesOnMalformedEntry(tmp_path: Path) -> None:
+    path = tmp_path / "registry.json"
+    path.write_text(json.dumps({"entries": [{"number": 1}]}))  # no versions key
+    with pytest.raises(ValueError, match="Malformed registry entry"):
+        loadPackageVersionRegistry(str(path))
+
+
+@responses.activate
+def test_writePackageVersionsToConsDb(client: ConsDbClient) -> None:
+    pv = PackageVersions(versions=dict(VERSIONS), versionNumber=42)
+    responses.post(
+        "http://example.com/consdb/insert/LSSTCam/cdb_lsstcam.exposure_quicklook/by_seq_num/20250624/123",
+        json={"message": "ok"},
+        match=[
+            responses.matchers.query_param_matcher({"u": "1"}),
+            responses.matchers.json_params_matcher(
+                {
+                    "table": "cdb_lsstcam.exposure_quicklook",
+                    "values": {
+                        "package_versions": {"versions": VERSIONS, "version_number": 42},
+                        "exposure_id": 5025062400123,
+                    },
+                }
+            ),
+        ],
+    )
+    writePackageVersionsToConsDb(client, "LSSTCam", 20250624, 123, pv, exposureId=5025062400123)
+
+
+@responses.activate
+def test_writePackageVersionsToConsDbComputesExposureId(client: ConsDbClient) -> None:
+    expectedExposureId = computeExposureId("LSSTCam", "O", 20250624, 123)
+    pv = PackageVersions(versions=dict(VERSIONS), versionNumber=42)
+    responses.post(
+        "http://example.com/consdb/insert/LSSTCam/cdb_lsstcam.exposure_quicklook/by_seq_num/20250624/123",
+        json={"message": "ok"},
+        match=[
+            responses.matchers.json_params_matcher(
+                {
+                    "table": "cdb_lsstcam.exposure_quicklook",
+                    "values": {
+                        "package_versions": {"versions": VERSIONS, "version_number": 42},
+                        "exposure_id": expectedExposureId,
+                    },
+                }
+            ),
+        ],
+    )
+    writePackageVersionsToConsDb(client, "LSSTCam", 20250624, 123, pv)
+
+
+def test_writePackageVersionsToConsDbRejectsBadIdentifiers(client: ConsDbClient) -> None:
+    pv = PackageVersions(versions=dict(VERSIONS))
+    with pytest.raises(ValueError, match="Invalid table name"):
+        writePackageVersionsToConsDb(client, "LSSTCam", 20250624, 123, pv, table="bad table; drop")
+    with pytest.raises(ValueError, match="Invalid column name"):
+        writePackageVersionsToConsDb(client, "LSSTCam", 20250624, 123, pv, column="bad-column")
+
+
+@responses.activate
+def test_readPackageVersionsFromConsDbParsesJsonObjectCell(client: ConsDbClient) -> None:
+    # the JSONB column coming back as an already-parsed JSON object; the query
+    # SQL is pinned here too (the join via the exposure table)
+    blob = {"versions": VERSIONS, "version_number": 42}
+    expectedQuery = (
+        "SELECT q.package_versions "
+        "FROM cdb_lsstcam.exposure_quicklook q "
+        "JOIN cdb_lsstcam.exposure e ON e.exposure_id = q.exposure_id "
+        "WHERE e.day_obs = 20250624 AND e.seq_num = 123"
+    )
+    responses.post(
+        "http://example.com/consdb/query",
+        json={"columns": [PACKAGE_VERSIONS_COLUMN], "data": [[blob]]},
+        match=[responses.matchers.json_params_matcher({"query": expectedQuery})],
+    )
+    pv = readPackageVersionsFromConsDb(client, "LSSTCam", 20250624, 123)
+    assert pv == PackageVersions(versions=dict(VERSIONS), versionNumber=42)
+
+
+@responses.activate
+def test_readPackageVersionsFromConsDbParsesJsonStringCell(client: ConsDbClient) -> None:
+    # ...and coming back as a JSON string, in case the server serialises
+    # JSONB that way instead
+    blob = json.dumps({"versions": VERSIONS, "version_number": 42})
+    responses.post(
+        "http://example.com/consdb/query",
+        json={"columns": [PACKAGE_VERSIONS_COLUMN], "data": [[blob]]},
+    )
+    pv = readPackageVersionsFromConsDb(client, "LSSTCam", 20250624, 123)
+    assert pv == PackageVersions(versions=dict(VERSIONS), versionNumber=42)
+
+
+@responses.activate
+def test_readPackageVersionsFromConsDbNoRowReturnsNone(client: ConsDbClient) -> None:
+    responses.post(
+        "http://example.com/consdb/query",
+        json={"columns": [PACKAGE_VERSIONS_COLUMN], "data": []},
+    )
+    assert readPackageVersionsFromConsDb(client, "LSSTCam", 20250624, 123) is None
+
+
+@responses.activate
+def test_readPackageVersionsFromConsDbNullCellReturnsNone(client: ConsDbClient) -> None:
+    responses.post(
+        "http://example.com/consdb/query",
+        json={"columns": [PACKAGE_VERSIONS_COLUMN], "data": [[None]]},
+    )
+    assert readPackageVersionsFromConsDb(client, "LSSTCam", 20250624, 123) is None
+
+
+@responses.activate
+def test_consDbRoundTrip(client: ConsDbClient) -> None:
+    # write -> read round-trip through the mocked server: whatever blob the
+    # write sends, handing it back through the query path reproduces the
+    # original object
+    pv = PackageVersions(versions=dict(VERSIONS), versionNumber=42)
+    responses.post(
+        "http://example.com/consdb/insert/LSSTCam/cdb_lsstcam.exposure_quicklook/by_seq_num/20250624/123",
+        json={"message": "ok"},
+    )
+    writePackageVersionsToConsDb(client, "LSSTCam", 20250624, 123, pv, exposureId=5025062400123)
+    requestBody = responses.calls[0].request.body
+    assert requestBody is not None
+    writtenBlob = json.loads(requestBody)["values"][PACKAGE_VERSIONS_COLUMN]
+    responses.post(
+        "http://example.com/consdb/query",
+        json={"columns": [PACKAGE_VERSIONS_COLUMN], "data": [[writtenBlob]]},
+    )
+    assert readPackageVersionsFromConsDb(client, "LSSTCam", 20250624, 123) == pv
+
+
+@responses.activate
+def test_writeBackdatedPackageVersions(client: ConsDbClient, tmp_path: Path) -> None:
+    path = getRegistryPath(str(tmp_path), "LSSTCam")
+    pv = PackageVersions(versions=dict(VERSIONS))
+    assert resolveVersionNumber(path, pv, timestamp="t0") == 1
+    responses.post(
+        "http://example.com/consdb/insert/LSSTCam/cdb_lsstcam.exposure_quicklook/by_seq_num/20250624/123",
+        json={"message": "ok"},
+        match=[
+            responses.matchers.json_params_matcher(
+                {
+                    "table": "cdb_lsstcam.exposure_quicklook",
+                    "values": {
+                        "package_versions": {"versions": VERSIONS, "version_number": 1},
+                        "exposure_id": 5025062400123,
+                    },
+                }
+            ),
+        ],
+    )
+    written = writeBackdatedPackageVersions(
+        client, "LSSTCam", 20250624, 123, versionNumber=1, registryPath=path, exposureId=5025062400123
+    )
+    assert written == PackageVersions(versions=dict(VERSIONS), versionNumber=1)
+
+
+def test_writeBackdatedPackageVersionsRejectsUnknownNumber(client: ConsDbClient, tmp_path: Path) -> None:
+    path = getRegistryPath(str(tmp_path), "LSSTCam")
+    resolveVersionNumber(path, PackageVersions(versions={"ts_wep": "v1"}), timestamp="t0")
+    with pytest.raises(ValueError, match="known numbers: \\[1\\]"):
+        writeBackdatedPackageVersions(client, "LSSTCam", 20250624, 123, versionNumber=7, registryPath=path)

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -35,6 +35,8 @@ from lsst.summit.utils.utils import detectObjectsInExp
 
 
 class PlottingTestCase(lsst.utils.tests.TestCase):
+    outputDir: str
+
     try:
         afwDataDir = lsst.utils.getPackageDir("afwdata")
     except Exception:
@@ -42,11 +44,11 @@ class PlottingTestCase(lsst.utils.tests.TestCase):
     filename = "postISRCCD_2020021800224-EMPTY~EMPTY-det000.fits.fz"
 
     @classmethod
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         cls.outputDir = tempfile.mkdtemp()
 
     @unittest.skipUnless(afwDataDir, "afwdata not available")
-    def test_plot(self):
+    def test_plot(self) -> None:
         """Test that the the plot is made and saved"""
         fullName = os.path.join(self.afwDataDir, "LATISS/postISRCCD", self.filename)
         exp = afwImage.ExposureF(fullName)
@@ -93,7 +95,7 @@ class PlottingTestCase(lsst.utils.tests.TestCase):
         plot(nparr)
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_quickLook.py
+++ b/tests/test_quickLook.py
@@ -37,7 +37,7 @@ from lsst.summit.utils.quickLook import QuickLookIsrTask, QuickLookIsrTaskConfig
 class QuickLookIsrTaskTestCase(unittest.TestCase):
     """Tests of the run method with fake data."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         self.mockConfig = isrMock.IsrMockLSSTConfig()
         self.camera = isrMock.IsrMockLSST(config=self.mockConfig).getCamera()
 
@@ -57,7 +57,7 @@ class QuickLookIsrTaskTestCase(unittest.TestCase):
         self.bfKernel = isrMock.BfKernelMockLSST(config=self.mockConfig).run()
         self.task = QuickLookIsrTask(config=QuickLookIsrTaskConfig())
 
-    def test_runQuickLook(self):
+    def test_runQuickLook(self) -> None:
         # Execute the run method with the mock data
         result = self.task.run(
             self.ccdExposure,
@@ -79,12 +79,12 @@ class QuickLookIsrTaskTestCase(unittest.TestCase):
             "Resulting exposure should be an instance of lsst.afw.image.Exposure",
         )
 
-    def test_runQuickLookMissingData(self):
+    def test_runQuickLookMissingData(self) -> None:
         # Test without any inputs other than the exposure.  And the PTC.
         result = self.task.run(self.ccdExposure, ptc=self.ptc)
         self.assertIsInstance(result.exposure, afwImage.Exposure)
 
-    def test_runQuickLookBadDark(self):
+    def test_runQuickLookBadDark(self) -> None:
         # Test with an incorrect dark frame
         bbox = self.ccdExposure.getBBox()
         bbox.grow(-20)
@@ -106,7 +106,7 @@ class QuickLookIsrTaskRunQuantumTests(lsst.utils.tests.TestCase):
     Adapted from the unit tests of ``CalibrateImageTask.runQuantum``
     """
 
-    def setUp(self):
+    def setUp(self) -> None:
         # These need to be real, not empty:
         self.mockConfig = isrMock.IsrMockLSSTConfig()
         self.camera = isrMock.IsrMockLSST(config=self.mockConfig).getCamera()
@@ -232,10 +232,10 @@ class QuickLookIsrTaskRunQuantumTests(lsst.utils.tests.TestCase):
             self.detector_id,
         )
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         del self.repo_path  # this removes the temporary directory
 
-    def test_runQuantum(self):
+    def test_runQuantum(self) -> None:
         config = ipIsr.IsrTaskConfig()
         # Remove some outputs
         config.doBinnedExposures = False
@@ -289,7 +289,7 @@ class QuickLookIsrTaskRunQuantumTests(lsst.utils.tests.TestCase):
             lsst.pipe.base.testUtils.runTestQuantum(task, self.butler, quantum, mockRun=False)
 
 
-def raiseExitMockError(*args):
+def raiseExitMockError(*args: object) -> None:
     """Raise a custom exception."""
     raise ExitMockError
 
@@ -304,7 +304,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_tmaUtils.py
+++ b/tests/test_tmaUtils.py
@@ -597,9 +597,11 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(len(eventsWithBlockInfo), 65)
         self.assertEqual(len(eventsWithoutBlockInfo), 4)
 
-        self.assertIsNotNone(eventsWithoutBlockInfo[0].blockInfos)
-        self.assertIsInstance(eventsWithoutBlockInfo[0].blockInfos, list)
-        self.assertEqual(len(eventsWithoutBlockInfo[0].blockInfos), 0)
+        firstBlockInfos = eventsWithoutBlockInfo[0].blockInfos
+        self.assertIsNotNone(firstBlockInfos)
+        self.assertIsInstance(firstBlockInfos, list)
+        assert firstBlockInfos is not None  # narrow for mypy; asserted non-None just above
+        self.assertEqual(len(firstBlockInfos), 0)
 
         event = eventsWithBlockInfo[0]
         self.assertIsInstance(event, TMAEvent)

--- a/tests/test_tmaUtils.py
+++ b/tests/test_tmaUtils.py
@@ -479,7 +479,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
         # test str(), repr(), and _ipython_display_() for an event
         print(str(events[0]))
         print(repr(events[0]))
-        print(events[0]._ipython_display_())
+        events[0]._ipython_display_()
 
         # spot-check both a slow and a track to print
         slews = [e for e in events if e.type == TMAState.SLEWING]

--- a/tests/test_tmaUtils.py
+++ b/tests/test_tmaUtils.py
@@ -24,6 +24,7 @@
 import asyncio
 import os
 import unittest
+from typing import Any
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -59,7 +60,7 @@ TESTDIR = os.path.abspath(os.path.dirname(__file__))
 vcr = getVcr()
 
 
-def getTmaEventTestTruthValues():
+def getTmaEventTestTruthValues() -> tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
     """Get the current truth values for the TMA event test cases.
 
     Returns
@@ -85,7 +86,7 @@ def getTmaEventTestTruthValues():
     return seqNums, startRows, endRows, types, endReasons
 
 
-def writeNewTmaEventTestTruthValues():
+def writeNewTmaEventTestTruthValues() -> None:
     """This function is used to write out the truth values for the test cases.
 
     If the internal event creation logic changes, these values can change, and
@@ -113,14 +114,14 @@ def writeNewTmaEventTestTruthValues():
             f.write(line + "\n")
 
 
-def makeValid(tma):
+def makeValid(tma: TMAStateMachine) -> None:
     """Helper function to turn a TMA into a valid state."""
     for name, value in tma._parts.items():
         if value == tma._UNINITIALIZED_VALUE:
             tma._parts[name] = 1
 
 
-def _turnOn(tma):
+def _turnOn(tma: TMAStateMachine) -> None:
     """Helper function to turn TMA axes on for testing.
 
     Do not call directly in normal usage or code, as this just arbitrarily
@@ -136,7 +137,7 @@ def _turnOn(tma):
 
 
 class TmaUtilsTestCase(lsst.utils.tests.TestCase):
-    def test_tmaInit(self):
+    def test_tmaInit(self) -> None:
         tma = TMAStateMachine()
         self.assertFalse(tma._isValid)
 
@@ -152,7 +153,7 @@ class TmaUtilsTestCase(lsst.utils.tests.TestCase):
         tma._parts["elevationSystemState"] = 1
         self.assertTrue(tma._isValid)
 
-    def test_tmaReferences(self):
+    def test_tmaReferences(self) -> None:
         """Check the linkage between the component lists and the _parts
         dict.
         """
@@ -166,7 +167,7 @@ class TmaUtilsTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(tma._parts["azimuthMotionState"], AxisMotionState.TRACKING)
         self.assertEqual(tma._parts["elevationMotionState"], AxisMotionState.TRACKING)
 
-    def test_getAxisAndType(self):
+    def test_getAxisAndType(self) -> None:
         # check both the long and short form names work
         for s in ["azimuthMotionState", "lsst.sal.MTMount.logevent_azimuthMotionState"]:
             self.assertEqual(getAxisAndType(s), ("azimuth", "MotionState"))
@@ -178,7 +179,7 @@ class TmaUtilsTestCase(lsst.utils.tests.TestCase):
         for s in ["azimuthSystemState", "lsst.sal.MTMount.logevent_azimuthSystemState"]:
             self.assertEqual(getAxisAndType(s), ("azimuth", "SystemState"))
 
-    def test_initStateLogic(self):
+    def test_initStateLogic(self) -> None:
         tma = TMAStateMachine()
         self.assertFalse(tma._isValid)
         self.assertFalse(tma.isMoving)
@@ -217,9 +218,17 @@ class TmaUtilsTestCase(lsst.utils.tests.TestCase):
 
 @vcr.use_cassette()
 class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
+    # class attributes populated in setUpClass
+    client: Any
+    dayObs: int
+    dayObsWithBlockInfo: int
+    tmaEventMaker: TMAEventMaker
+    events: list[TMAEvent]
+    sampleData: Any
+
     @classmethod
     @vcr.use_cassette()
-    def setUpClass(cls):
+    def setUpClass(cls) -> None:
         try:
             cls.client = makeEfdClient(testing=True)
         except RuntimeError:
@@ -233,19 +242,19 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
         cls.sampleData = cls.tmaEventMaker._data[cls.dayObs]  # pull the data from the object and test length
 
     @vcr.use_cassette()
-    def tearDown(self):
+    def tearDown(self) -> None:
         loop = asyncio.get_event_loop()
         if self.client.influx_client is not None:
             loop.run_until_complete(self.client.influx_client.close())
 
     @vcr.use_cassette()
-    def test_events(self):
+    def test_events(self) -> None:
         data = self.sampleData
         self.assertIsInstance(data, pd.DataFrame)
         self.assertEqual(len(data), 800)
 
     @vcr.use_cassette()
-    def test_rowDataForValues(self):
+    def test_rowDataForValues(self) -> None:
         rowsFor = set(self.sampleData["rowFor"])
         self.assertEqual(len(rowsFor), 6)
 
@@ -262,13 +271,13 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
         self.assertSetEqual(rowsFor, correct)
 
     @vcr.use_cassette()
-    def test_monotonicTimeInDataframe(self):
+    def test_monotonicTimeInDataframe(self) -> None:
         # ensure that each row is later than the previous
         times = self.sampleData["private_efdStamp"]
         self.assertTrue(np.all(np.diff(times) > 0))
 
     @vcr.use_cassette()
-    def test_monotonicTimeApplicationOfRows(self):
+    def test_monotonicTimeApplicationOfRows(self) -> None:
         # ensure you can apply rows in the correct order
         tma = TMAStateMachine()
         row1 = self.sampleData.iloc[0]
@@ -285,7 +294,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
             tma.apply(row1)
 
     @vcr.use_cassette()
-    def test_fullDaySequence(self):
+    def test_fullDaySequence(self) -> None:
         # make sure we can apply all the data from the day without falling
         # through the logic sieve
         for engineering in (True, False):
@@ -297,7 +306,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
                 tma.apply(row)
 
     @vcr.use_cassette()
-    def test_endToEnd(self):
+    def test_endToEnd(self) -> None:
         eventMaker = self.tmaEventMaker
         events = eventMaker.getEvents(self.dayObs)
         self.assertIsInstance(events, list)
@@ -322,7 +331,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(len(eventSet), len(slews))
 
     @vcr.use_cassette()
-    def test_noDataBehaviour(self):
+    def test_noDataBehaviour(self) -> None:
         eventMaker = self.tmaEventMaker
         noDataDayObs = 19600101  # do not use 19700101 - there is data for that day!
         with self.assertLogs(level="WARNING") as cm:
@@ -334,7 +343,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
             self.assertIn(correctMsg, msg)
 
     @vcr.use_cassette()
-    def test_helperFunctions(self):
+    def test_helperFunctions(self) -> None:
         eventMaker = self.tmaEventMaker
         events = eventMaker.getEvents(self.dayObs)
 
@@ -345,7 +354,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(slews, foundSlews)
         self.assertEqual(tracks, foundTracks)
 
-    def test_filterBadValues(self):
+    def test_filterBadValues(self) -> None:
         # NB: if you add enough spurious values that the median is no longer
         # the value around which your "good" values are oscillating the first
         # two points will get replaced and this can be very confusing!
@@ -442,7 +451,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(nReplaced, 1)
 
     @vcr.use_cassette()
-    def test_getEvent(self):
+    def test_getEvent(self) -> None:
         # test the singular event getter, and what happens if the event doesn't
         # exist for the day
         eventMaker = self.tmaEventMaker
@@ -463,7 +472,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
             self.assertIn(correctMsg, msg)
 
     @vcr.use_cassette()
-    def test_printing(self):
+    def test_printing(self) -> None:
         eventMaker = self.tmaEventMaker
         events = eventMaker.getEvents(self.dayObs)
 
@@ -487,7 +496,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
         eventMaker.printTmaDetailedState(tma)
 
     @vcr.use_cassette()
-    def test_getAxisData(self):
+    def test_getAxisData(self) -> None:
         eventMaker = self.tmaEventMaker
         events = eventMaker.getEvents(self.dayObs)
 
@@ -506,7 +515,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
         plotEvent(self.client, events[0], azimuthData=azData, elevationData=elData)
 
     @vcr.use_cassette()
-    def test_plottingAndCommands(self):
+    def test_plottingAndCommands(self) -> None:
         eventMaker = self.tmaEventMaker
         events = eventMaker.getEvents(self.dayObs)
         event = events[10]  # this one has commands, and we'll check that later
@@ -528,7 +537,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
         del fig
 
     @vcr.use_cassette()
-    def test_findEvent(self):
+    def test_findEvent(self) -> None:
         eventMaker = self.tmaEventMaker
         # addBlockInfo=True because it shouldn't affect the comparison, and
         # this also then ensures that the code is exercised too
@@ -579,7 +588,7 @@ class TMAEventMakerTestCase(lsst.utils.tests.TestCase):
         self.assertIsNone(found, lastEvent)
 
     @vcr.use_cassette()
-    def test_eventAssociatedWith(self):
+    def test_eventAssociatedWith(self) -> None:
         eventMaker = self.tmaEventMaker
         events = eventMaker.getEvents(self.dayObsWithBlockInfo)
         eventsWithBlockInfo = [e for e in events if e.blockInfos]
@@ -630,7 +639,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,7 @@ import copy
 import datetime
 import itertools
 import unittest
-from typing import Iterable
+from typing import Any, Iterable
 
 import astropy.time
 import astropy.units as u
@@ -81,14 +81,14 @@ class ExpSkyPositionOffsetTestCase(lsst.utils.tests.TestCase):
 
     def test_getExpPositionOffset(self) -> None:
         epsilon = 0.0001
-        ra1s = [0, 45, 90]
+        ra1s: Any = [0, 45, 90]
         ra2s = copy.copy(ra1s)
         ra2s.extend([r + epsilon for r in ra1s])
         ra1s = np.deg2rad(ra1s)
         ra2s = np.deg2rad(ra2s)
 
         epsilon = 0.0001
-        dec1s = [0, 45, 90]
+        dec1s: Any = [0, 45, 90]
         dec2s = copy.copy(dec1s)
         dec2s.extend([d + epsilon for d in dec1s[:-1]])  # skip last point as >90 not allowed for dec
 
@@ -276,7 +276,7 @@ class QuantileTestCase(lsst.utils.tests.TestCase):
                     edges1 = getQuantiles(data, nColors)
                 self.assertIn("Data range is very large", cm.output[0])
             else:
-                with self.assertNoLogs(level="WARNING") as cm:
+                with self.assertNoLogs(level="WARNING"):
                     edges1 = getQuantiles(data, nColors)
             edges2 = np.nanquantile(data, np.linspace(0, 1, nColors + 1))  # must check with nanquantile
             np.testing.assert_almost_equal(edges1, edges2, decimal=decimal)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -63,7 +63,7 @@ from lsst.summit.utils.utils import (
 class ExpSkyPositionOffsetTestCase(lsst.utils.tests.TestCase):
     """A test case for testing sky position offsets for exposures."""
 
-    def setUp(self):
+    def setUp(self) -> None:
         camera = Latiss.getCamera()
         self.assertTrue(len(camera) == 1)
         self.detector = camera[0]
@@ -79,7 +79,7 @@ class ExpSkyPositionOffsetTestCase(lsst.utils.tests.TestCase):
             location=AUXTEL_LOCATION,
         )
 
-    def test_getExpPositionOffset(self):
+    def test_getExpPositionOffset(self) -> None:
         epsilon = 0.0001
         ra1s = [0, 45, 90]
         ra2s = copy.copy(ra1s)
@@ -143,7 +143,7 @@ class MiscUtilsTestCase(lsst.utils.tests.TestCase):
     def setUp(self) -> None:
         return super().setUp()
 
-    def test_getFieldNameAndTileNumber(self):
+    def test_getFieldNameAndTileNumber(self) -> None:
         field, num = getFieldNameAndTileNumber("simple")
         self.assertEqual(field, "simple")
         self.assertIsNone(num)
@@ -176,7 +176,7 @@ class MiscUtilsTestCase(lsst.utils.tests.TestCase):
         self.assertEqual(field, "test_321a:asd_asd-dsa")
         self.assertEqual(num, 321)
 
-    def test_getAirmassSeeingCorrection(self):
+    def test_getAirmassSeeingCorrection(self) -> None:
         for airmass in (1.1, 2.0, 20.0):
             correction = getAirmassSeeingCorrection(airmass)
             self.assertGreater(correction, 0.01)
@@ -188,14 +188,14 @@ class MiscUtilsTestCase(lsst.utils.tests.TestCase):
         with self.assertRaises(ValueError):
             getAirmassSeeingCorrection(0.5)
 
-    def test_getFilterSeeingCorrection(self):
+    def test_getFilterSeeingCorrection(self) -> None:
         for filterName in ("SDSSg_65mm", "SDSSr_65mm", "SDSSi_65mm"):
             with self.assertWarns(FutureWarning):
                 correction = getFilterSeeingCorrection(filterName)
             self.assertGreater(correction, 0.5)
             self.assertLess(correction, 1.5)
 
-    def test_getBandpassSeeingCorrection(self):
+    def test_getBandpassSeeingCorrection(self) -> None:
         for filterName in (
             "SDSSg_65mm",
             "SDSSr_65mm",
@@ -211,7 +211,7 @@ class MiscUtilsTestCase(lsst.utils.tests.TestCase):
             self.assertGreater(correction, 0.5)
             self.assertLess(correction, 1.5)
 
-    def test_quickSmooth(self):
+    def test_quickSmooth(self) -> None:
         # just test that it runs and returns the right shape. It's a wrapper on
         # scipy.ndimage.gaussian_filter we can trust that it does what it
         # should, and we just test the interface hasn't bitrotted on either end
@@ -219,7 +219,7 @@ class MiscUtilsTestCase(lsst.utils.tests.TestCase):
         data = quickSmooth(data, 5.0)
         self.assertEqual(data.shape, (100, 100))
 
-    def test_getCurrentDayObsDatetime(self):
+    def test_getCurrentDayObsDatetime(self) -> None:
         """Just a type check and a basic sanity check on the range.
 
         Setting days=3 as the tolerance just because of timezones and who knows
@@ -230,21 +230,21 @@ class MiscUtilsTestCase(lsst.utils.tests.TestCase):
         self.assertLess(dt, datetime.date.today() + datetime.timedelta(days=3))
         self.assertGreater(dt, datetime.date.today() - datetime.timedelta(days=3))
 
-    def test_getCurrentDayObsInt(self):
+    def test_getCurrentDayObsInt(self) -> None:
         """Just a type check and a basic sanity check on the range."""
         dayObs = getCurrentDayObsInt()
         self.assertIsInstance(dayObs, int)
         self.assertLess(dayObs, 21000101)
         self.assertGreater(dayObs, 19700101)
 
-    def test_getCurrentDayObsHumanStr(self):
+    def test_getCurrentDayObsHumanStr(self) -> None:
         """Just a basic formatting check."""
         dateStr = getCurrentDayObsHumanStr()
         self.assertIsInstance(dateStr, str)
         self.assertEqual(len(dateStr), 10)
         self.assertRegex(dateStr, r"\d{4}-\d{2}-\d{2}")
 
-    def test_getSunAngle(self):
+    def test_getSunAngle(self) -> None:
         """Just a basic sanity check on the range."""
         testTime = Time("2021-09-15T16:00:00", format="isot", scale="utc")
         sunAngle = getSunAngle(testTime)
@@ -262,7 +262,7 @@ class QuantileTestCase(lsst.utils.tests.TestCase):
     def setUp(self) -> None:
         return super().setUp()
 
-    def test_quantiles(self):
+    def test_quantiles(self) -> None:
         # We understand that our algorithm gives very large rounding error
         # compared to the generic numpy method. But still test it.
         np.random.seed(1234)
@@ -283,7 +283,7 @@ class QuantileTestCase(lsst.utils.tests.TestCase):
 
 
 class ImageBasedTestCase(lsst.utils.tests.TestCase):
-    def test_fluxFromFootprint(self):
+    def test_fluxFromFootprint(self) -> None:
         image = afwImage.Image(
             np.arange(8100, dtype=np.int32).reshape(90, 90), xy0=lsst.geom.Point2I(10, 12), dtype="I"
         )
@@ -337,14 +337,14 @@ class ImageBasedTestCase(lsst.utils.tests.TestCase):
 
 
 class IdTestCase(lsst.utils.tests.TestCase):
-    def test_exposure_id(self):
+    def test_exposure_id(self) -> None:
         self.assertEqual(computeExposureId("latiss", "O", 20240402, 35), 2024040200035)
         self.assertEqual(computeExposureId("LATISS", "C", 20240402, 35), 2024040200035)
         self.assertEqual(computeExposureId("LSSTComCamSim", "S", 20240402, 35), 7024040200035)
         with self.assertRaises(ValueError):
             computeExposureId("bad_instrument", "O", 20240402, 35)
 
-    def test_ccdexposure_id(self):
+    def test_ccdexposure_id(self) -> None:
         self.assertEqual(computeCcdExposureId("latiss", 2024040200035, 0), 5205 * (2**23) + 35 * 256 + 0)
         with self.assertRaises(ValueError):
             computeCcdExposureId("latiss", 20240402000035, 1)
@@ -357,7 +357,7 @@ class IdTestCase(lsst.utils.tests.TestCase):
             5 * (2**37) + 5205 * (2**23) + 35 * 256 + 2,
         )
 
-    def test_calcEclipticCoords(self):
+    def test_calcEclipticCoords(self) -> None:
         ras = [0, 1, 45, 90, 180, 270, 359.9]
         decs = [-90, -80, -45, -1, 0, 1, 45, 90]
 
@@ -373,7 +373,7 @@ class TestMemory(lsst.utils.tests.MemoryTestCase):
     pass
 
 
-def setup_module(module):
+def setup_module(module: object) -> None:
     lsst.utils.tests.init()
 
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,7 +26,7 @@ import vcr
 __all__ = ("getVcr",)
 
 
-def getVcr():
+def getVcr() -> vcr.VCR:
     """Get a VCR object for use in tests.
 
     Use record_mode="none" to run tests for normal operation. To update files


### PR DESCRIPTION
Rapid analysis records, for every image it dispatches, the versions of the science packages that determine the AOS results, plus an overall incrementing version number mapped in a small per-instrument on-disk registry. The data model for that — the PackageVersions dataclass, its JSON serialisation, and the registry read/write — moves here from rubintv_production so that users without access to that package can consume the data.

ConsDB is about to grow a JSONB column for this. writePackageVersionsToConsDb and readPackageVersionsFromConsDb round-trip the pinned blob shape ({"versions": {...}, "version_number": N}) through it, defaulting to cdb_<instrument>.exposure_quicklook.package_versions until the schema change lands (table and column are parameterised in case it lands elsewhere). loadPackageVersionRegistry and writeBackdatedPackageVersions support back-filling ConsDB for images processed before the column existed, expanding a known overall version number to its full package-version set via the registry.

The blob shape and the deployed registry file format are pinned by verbatim-decode unit tests, and the ConsDB read/write paths are tested against a mocked server via responses, including the write -> read round-trip.